### PR TITLE
Allow "*default*" as netvm

### DIFF
--- a/plugins/modules/qubesos.py
+++ b/plugins/modules/qubesos.py
@@ -301,13 +301,13 @@ class QubesVirt(object):
         vmtype="AppVM",
         label="red",
         template=None,
-        netvm="default",
+        netvm="*default*",
     ):
         """Start the machine via the given vmid"""
         template_vm = ""
         if template:
             template_vm = template
-        if netvm == "default":
+        if netvm == "*default*":
             network_vm = self.app.default_netvm
         elif not netvm:
             network_vm = None
@@ -389,6 +389,8 @@ class QubesVirt(object):
             # To make sure that we allow VMs with netvm
             if prefs["netvm"] == "":
                 netvm = ""
+            elif prefs["netvm"] == "*default*":
+                netvm = self.app.default_netvm
             else:
                 netvm = self.app.domains[prefs["netvm"]]
             if vm.netvm != netvm:
@@ -508,7 +510,7 @@ def core(module):
                 return VIRT_FAILED, {"Invalid property value type": key}
 
             # Make sure that the netvm exists
-            if key == "netvm" and val not in ["", "none", "None"]:
+            if key == "netvm" and val not in ["*default*", "", "none", "None"]:
                 try:
                     vm = v.get_vm(val)
                 except KeyError:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,28 @@ def vmname():
     return f"test-vm-{uuid.uuid4().hex[:8]}"
 
 
+@pytest.fixture(scope="function")
+def vm(qubes, request):
+    """Generate a VM with default configurations"""
+    vmname = f"test-vm-{uuid.uuid4().hex[:8]}"
+    core(Module({"state": "present", "name": vmname}))
+    request.node.mark_vm_created(vmname)
+
+    qubes.domains.refresh_cache(force=True)
+    return qubes.domains[vmname]
+
+
+@pytest.fixture(scope="function")
+def netvm(qubes, request):
+    vmname = f"test-netvm-{uuid.uuid4().hex[:8]}"
+    props = {"provides_network": True}
+    core(Module({"state": "present", "name": vmname, "properties": props}))
+    request.node.mark_vm_created(vmname)
+
+    qubes.domains.refresh_cache(force=True)
+    return qubes.domains[vmname]
+
+
 @pytest.fixture(autouse=True)
 def cleanup_vm(qubes, request):
     """Ensure any test VM is removed after test"""

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -193,6 +193,43 @@ def test_missing_netvm(qubes, vmname, request):
     assert "Missing netvm" in res
 
 
+def test_default_netvm(qubes, vm, netvm, request):
+    """
+    Able to reset back to default netvm without needing to mention it by name
+    """
+    default_netvm = vm.netvm
+
+    # Change to non-default netvm
+    change_netvm_rc, change_netvm_res = core(
+        Module(
+            {
+                "state": "present",
+                "name": vm.name,
+                "properties": {"netvm": netvm.name},
+            }
+	)
+    )
+    assert "netvm" in change_netvm_res["Properties updated"]
+    assert change_netvm_rc == VIRT_SUCCESS
+
+    # Ability to reset back to default netvm, whichever it is
+    reset_netvm_rc, reset_netvm_res = core(
+        Module(
+            {
+                "state": "present",
+                "name": vm.name,
+                "properties": {"netvm": "*default*"},
+            }
+	)
+    )
+    assert "netvm" in reset_netvm_res["Properties updated"]
+    assert default_netvm != netvm
+    assert reset_netvm_rc == VIRT_SUCCESS
+
+    qubes.domains.refresh_cache(force=True)
+    assert qubes.domains[vm.name].netvm == default_netvm
+
+
 def test_missing_default_dispvm(qubes):
     # default_dispvm does not exist
     rc, res = core(


### PR DESCRIPTION
Previously, some code paths did seem to indicate that setting 'default' as the netvm would set it as the `default_netvm`. But in practice it would error out with:

>  fatal: [localhost]: FAILED! => {"changed": false, "msg": {"Missing netvm": "default"}, "rc": 1}

This is particularly necessary in management qubes where information about already-existing netvms is not directly available.