### PR TITLE
Set user parameter for qubes.VMRootShell policy in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ admin.vm.Remove              * mgmtvm @tag:created-by-mgmtvm allow target=dom0
 qubes.Filecopy       * mgmtvm @tag:created-by-mgmtvm allow
 qubes.WaitForSession * mgmtvm @tag:created-by-mgmtvm allow
 qubes.VMShell        * mgmtvm @tag:created-by-mgmtvm allow
-qubes.VMRootShell    * mgmtvm @tag:created-by-mgmtvm allow
+qubes.VMRootShell    * mgmtvm @tag:created-by-mgmtvm allow user=root
 ```
 
 ### 4. Update Admin Local Read-Write policy


### PR DESCRIPTION
According to qubes.VMRootShell:

```bash
# This is the same as qubes.VMShell. The actual difference is in qrexec policy,
# which contains 'user=root' option.
```

Without the user parameter on a policy, dom0 executes the RPC as the default user:

```console
mgmtvm$ echo "whoami" | qvm-run --pass-io --service workvm qubes.VMRootShell
user
```

This change updates the documentation to make qubes.VMRootShell behave as intended:

```console
mgmtvm$ echo "whoami" | qvm-run --pass-io --service workvm qubes.VMRootShell
root
```

Closes QubesOS/qubes-issues#9939