### PR TITLE
Add qubes_shell_rpc option

### DIFF
--- a/plugins/connection/qubes.py
+++ b/plugins/connection/qubes.py
@@ -39,12 +39,6 @@ DOCUMENTATION = """
         vars:
             - name: inventory_hostname
             - name: ansible_host
-      remote_user:
-        description:
-            - The user to execute as inside the qube.
-        default: user
-        vars:
-            - name: ansible_user
       qubes_shell_rpc:
         description:
             - Qubes shell RPC to execute inside the qube.
@@ -81,12 +75,6 @@ class Connection(ConnectionBase):
         )
         self._remote_vmname = self._play_context.remote_addr
         self._connected = False
-        # Use the provided remote_user if set; otherwise default to "user".
-        self.user = (
-            self._play_context.remote_user
-            if self._play_context.remote_user
-            else "user"
-        )
 
     def _qubes(
         self, cmd: str, in_data: bytes = None
@@ -104,8 +92,6 @@ class Connection(ConnectionBase):
             cmd += "\n"
 
         local_cmd = ["qvm-run", "--pass-io", "--service"]
-        if self.user != "user":
-            local_cmd.extend(["-u", self.user])
         local_cmd.extend([self._remote_vmname, self.get_option("qubes_shell_rpc")])
         local_cmd_bytes = [
             to_bytes(arg, errors="surrogate_or_strict") for arg in local_cmd

--- a/plugins/connection/qubes.py
+++ b/plugins/connection/qubes.py
@@ -45,6 +45,12 @@ DOCUMENTATION = """
         default: user
         vars:
             - name: ansible_user
+      qubes_shell_rpc:
+        description:
+            - Qubes shell RPC to execute inside the qube.
+        default: qubes.VMShell
+        vars:
+            - name: qubes_shell_rpc
 """
 
 import subprocess
@@ -83,7 +89,7 @@ class Connection(ConnectionBase):
         )
 
     def _qubes(
-        self, cmd: str, in_data: bytes = None, shell: str = "qubes.VMShell"
+        self, cmd: str, in_data: bytes = None
     ):
         """
         Execute a command in the qube via qvm-run.
@@ -100,7 +106,7 @@ class Connection(ConnectionBase):
         local_cmd = ["qvm-run", "--pass-io", "--service"]
         if self.user != "user":
             local_cmd.extend(["-u", self.user])
-        local_cmd.extend([self._remote_vmname, shell])
+        local_cmd.extend([self._remote_vmname, self.get_option("qubes_shell_rpc")])
         local_cmd_bytes = [
             to_bytes(arg, errors="surrogate_or_strict") for arg in local_cmd
         ]

--- a/plugins/connection/qubes.py
+++ b/plugins/connection/qubes.py
@@ -158,12 +158,7 @@ class Connection(ConnectionBase):
         with open(in_path, "rb") as fobj:
             source_data = fobj.read()
 
-        # Try using VMRootShell first; fallback to VMShell if needed.
-        retcode, _, _ = self._qubes(
-            f'cat > "{out_path}"\n', source_data, shell="qubes.VMRootShell"
-        )
-        if retcode == 127:
-            retcode, _, _ = self._qubes(f'cat > "{out_path}"\n', source_data)
+        retcode, _, _ = self._qubes(f'cat > "{out_path}"\n', source_data)
         if retcode != 0:
             raise RuntimeError(f"Failed to put_file to {out_path}")
 


### PR DESCRIPTION
This PR replaces the ansible_user option with the qubes_shell_rpc option, which defaults to qubes.VMShell. The plugin always uses the qubes_shell_rpc value instead of trying other RPCs.

Combined with the updated qubes.VMRootShell policy in the README in PR https://github.com/fepitre/qubes-ansible/pull/4, this fixes running privileged tasks on qubes without passwordless root, like minimal qubes. It also enables other functionalities.

## Root connections to minimal qubes

There was no way to run tasks as root on qubes without the qubes-core-agent-passwordless-root package installed. Plays that use `become: true` fail on minimal qubes because the default user can't assume root privileges at all.

This fix depends on the updated qubes.VMRootShell policy described in PR https://github.com/fepitre/qubes-ansible/pull/4:

```
qubes.VMRootShell    * mgmtvm @tag:created-by-mgmtvm allow user=root
```

This change enables connecting to minimal qubes as the default user by default:

```yaml
---
- name: Connect to minimal qube as default user
  hosts: fedora-41-minimal
  connection: qubes
  tasks:
    ...
```

As well as root:

```yaml
---
- name: Connect to minimal qube as root
  hosts: fedora-41-minimal
  connection: qubes
  vars:
    qubes_shell_rpc: qubes.VMRootShell
  tasks:
    ...
```

`become: true` still works on qubes with qubes-core-agent-passwordless-root installed:

```yaml
---
- name: Connect to regular qube as root through "become: true"
  hosts: fedora-41
  connection: qubes
  become: true
  tasks:
    ...
```

`become: true` will still fail on minimal qubes, as expected.

`qubes_shell_rpc: qubes.VMRootShell` also works on regular qubes:

```yaml
---
- name: Connect to regular qube as root through qubes.VMRootShell
  hosts: fedora-41
  connection: qubes
  vars:
    qubes_shell_rpc: qubes.VMRootShell
  tasks:
    ...
```

## Shell predictability

This change makes the connection plugin always use the value of qubes_shell_rpc to connect to remote qubes. This option defaults to qubes.VMShell.

Previously, the connection plugin tried qubes.VMRootShell to transfer files and only used qubes.VMShell if qubes.VMRootShell failed.

The qubes.VMRootShell policy in the README doesn't set the user parameter to root. With this configuration, qubes.VMRootShell is the same as qubes.VMShell, anyway.

I'm not sure why elevating privileges in the put_file method was necessary. In my limited testing, using a shell with default user privileges hasn't caused any obvious problems.

## Custom users and shells

This change also enables connecting to qubes as arbitrary users through policy parameters and arbitrary shells through custom RPCs.

With qubes.VMAliceShell symlinked to qubes.VMShell, this policy allows Ansible to connect as alice:

```
qubes.VMAliceShell * mgmtvm @tag:created-by-mgmtvm allow user=alice
```

Users can define their own RPCs to run non-Bourne shells (see [ansible_shell_type](https://docs.ansible.com/ansible/latest/inventory_guide/intro_inventory.html#ansible-shell-type)) or even shells in containers.

## Unified interface between dom0 and domUs

The ansible_user option is unusable on domUs like the mgmtvm described in the README. This option is only usable on dom0. The qvm-run command's `-u` option is disallowed on VMs:

```console
mgmtvm$ qvm-run --pass-io --service -u user workvm qubes.VMShell
...
ValueError: non-default user not possible for calls from VM
```

Instead of providing two methods of configuring the remote user, one of which only works on dom0, this change removes the half-functional ansible_user option.

Closes QubesOS/qubes-issues#9934
Closes QubesOS/qubes-issues#9938