### PR TITLE
Fix Admin API clone

### DIFF
--- a/plugins/modules/qubesos.py
+++ b/plugins/modules/qubesos.py
@@ -319,7 +319,8 @@ class QubesVirt(object):
             vm.netvm = network_vm
         elif vmtype in ["StandaloneVM", "TemplateVM"] and template_vm:
             vm = self.app.clone_vm(template_vm, vmname, vmtype, ignore_errors=(self.app.local_name != "dom0"))
-            vm.label = label
+            if vmtype == "StandaloneVM":
+                vm.label = label
         return 0
 
     def start(self, vmname):

--- a/plugins/modules/qubesos.py
+++ b/plugins/modules/qubesos.py
@@ -318,7 +318,7 @@ class QubesVirt(object):
             )
             vm.netvm = network_vm
         elif vmtype in ["StandaloneVM", "TemplateVM"] and template_vm:
-            vm = self.app.clone_vm(template_vm, vmname, vmtype)
+            vm = self.app.clone_vm(template_vm, vmname, vmtype, ignore_errors=(self.app.local_name != "dom0"))
             vm.label = label
         return 0
 


### PR DESCRIPTION
In my testing, I could not clone system templates, like fedora-41-xfce and fedora-41-minimal, from `mgmtvm`:

```yaml
---
- hosts: localhost
  connection: local
  tasks:
      - name: Clone fedora-41-xfce template
        qubesos:
          guest: fedora-41-xfce-clone
          vmtype: "TemplateVM"
          state: present
          template: "fedora-41-xfce"
```

I think this was due to a couple of issues:

1. The [Admin API does not support appmenus](https://github.com/QubesOS/qubes-issues/issues/4809) on Qubes OS 4.2
2. I did not want to add system templates to `include/admin-local-rwx`, which would allow `mgmtvm` to modify their attributes.

This PR...

1. Fixes the first issue by setting the `ignore_errors` flag on `clone_vm` when the local qube's name is not "dom0"
2. Adds a new example policy that allows only the RPCs necessary to clone target qubes to address the second issue
3. Fixes a bug that caused cloned templates to receive the label in the task's parameters instead of the parent's label

Closes QubesOS/qubes-issues#9932