### PR TITLE
Fix connecting minimal qubes as root

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ admin.vm.Remove              * mgmtvm @tag:created-by-mgmtvm allow target=dom0
 qubes.Filecopy       * mgmtvm @tag:created-by-mgmtvm allow
 qubes.WaitForSession * mgmtvm @tag:created-by-mgmtvm allow
 qubes.VMShell        * mgmtvm @tag:created-by-mgmtvm allow
-qubes.VMRootShell    * mgmtvm @tag:created-by-mgmtvm allow
+qubes.VMRootShell    * mgmtvm @tag:created-by-mgmtvm allow user=root
 ```
 
 ### 4. Update Admin Local Read-Write policy

--- a/plugins/connection/qubes.py
+++ b/plugins/connection/qubes.py
@@ -158,12 +158,7 @@ class Connection(ConnectionBase):
         with open(in_path, "rb") as fobj:
             source_data = fobj.read()
 
-        # Try using VMRootShell first; fallback to VMShell if needed.
-        retcode, _, _ = self._qubes(
-            f'cat > "{out_path}"\n', source_data, shell="qubes.VMRootShell"
-        )
-        if retcode == 127:
-            retcode, _, _ = self._qubes(f'cat > "{out_path}"\n', source_data)
+        retcode, _, _ = self._qubes(f'cat > "{out_path}"\n', source_data)
         if retcode != 0:
             raise RuntimeError(f"Failed to put_file to {out_path}")
 

--- a/plugins/connection/qubes.py
+++ b/plugins/connection/qubes.py
@@ -42,6 +42,9 @@ DOCUMENTATION = """
       remote_user:
         description:
             - The user to execute as inside the qube.
+        choices:
+            - user
+            - root
         default: user
         vars:
             - name: ansible_user
@@ -83,7 +86,7 @@ class Connection(ConnectionBase):
         )
 
     def _qubes(
-        self, cmd: str, in_data: bytes = None, shell: str = "qubes.VMShell"
+        self, cmd: str, in_data: bytes = None
     ):
         """
         Execute a command in the qube via qvm-run.
@@ -97,10 +100,12 @@ class Connection(ConnectionBase):
         if not cmd.endswith("\n"):
             cmd += "\n"
 
-        local_cmd = ["qvm-run", "--pass-io", "--service"]
-        if self.user != "user":
-            local_cmd.extend(["-u", self.user])
-        local_cmd.extend([self._remote_vmname, shell])
+        local_cmd = ["qvm-run", "--pass-io", "--service", self._remote_vmname]
+        # The Ansible module framework catches invalid remote_user values
+        if self.user == "root":
+            local_cmd.append("qubes.VMRootShell")
+        else:
+            local_cmd.append("qubes.VMShell")
         local_cmd_bytes = [
             to_bytes(arg, errors="surrogate_or_strict") for arg in local_cmd
         ]


### PR DESCRIPTION
Ansible "become" modules don't work on qubes without the `qubes-core-agent-passwordless-root` package installed, like minimal qubes, by design. Users should use the `remote_user` to login as root on minimal qubes. However, this functionality is broken due to a number of issues in the connection module and documentation.

This PR...

- Updates the `qubes.VMRootShell` policy in the README
- Adds valid choices for the `remote_user` option ([discussion](https://github.com/QubesOS/qubes-ansible/pull/5#issuecomment-2840488749))
- Chooses the appropriate shell RPC for the given user

Closes QubesOS/qubes-issues#9939
Closes QubesOS/qubes-issues#9934
Closes QubesOS/qubes-issues#9938