### PR TITLE
Strategy plugin to isolate dom0 from untrusted Ansible data

### DIFF
--- a/plugins/callback/qubesos_strategy_guard.py
+++ b/plugins/callback/qubesos_strategy_guard.py
@@ -1,8 +1,8 @@
 # Copyright (C) 2025 Guillaume Chinal <guiiix@invisiblethingslab.com>
 #
-# This program is free software; you can redistribute it and/or modify
+# This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
+# the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -10,8 +10,8 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License along
-# with this program. If not, see <https://www.gnu.org/licenses/>.
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/plugins/callback/qubesos_strategy_guard.py
+++ b/plugins/callback/qubesos_strategy_guard.py
@@ -1,0 +1,48 @@
+# Copyright (C) 2025 Guillaume Chinal <guiiix@invisiblethingslab.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from ansible.plugins.callback import CallbackBase
+
+
+class CallbackModule(CallbackBase):
+    CALLBACK_VERSION = 2.0
+    CALLBACK_TYPE = 'notification'
+    CALLBACK_NAME = 'qubesos_strategy_guard'
+
+    def v2_playbook_on_play_start(self, play):
+        self._play = play
+
+    def v2_runner_on_start(self, host, task):
+        if self._play.strategy == "qubes_proxy":
+            return
+
+        if task._variable_manager is None:
+            return
+
+        task_connection = task._variable_manager.get_vars(
+                play=self._play,
+                host=host,
+                task=task,
+                include_hostvars=True,
+                include_delegate_to=True
+        ).get('ansible_connection')
+
+        if task_connection == "qubes":
+            self._display.warning(
+                "Using qubes connection plugin without qubes_proxy strategy is "
+                "considered insecure and may lead to dom0 compromise. Continue "
+                "at your own risk.")

--- a/plugins/connection/qubes.py
+++ b/plugins/connection/qubes.py
@@ -2,9 +2,9 @@
 # Copyright (C) 2018 Kushal Das
 # Copyright (C) 2025 Frédéric Pierret (fepitre) <frederic@invisiblethingslab.com>
 #
-# This program is free software; you can redistribute it and/or modify
+# This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
+# the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -12,8 +12,8 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License along
-# with this program. If not, see <https://www.gnu.org/licenses/>.
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/plugins/modules/qubesos.py
+++ b/plugins/modules/qubesos.py
@@ -3,9 +3,9 @@
 # Copyright (C) 2018 Kushal Das
 # Copyright (C) 2025 Frédéric Pierret (fepitre) <frederic@invisiblethingslab.com>
 #
-# This program is free software; you can redistribute it and/or modify
+# This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
+# the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -13,8 +13,8 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License along
-# with this program. If not, see <https://www.gnu.org/licenses/>.
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/plugins/strategy/qubes_proxy.py
+++ b/plugins/strategy/qubes_proxy.py
@@ -1,8 +1,8 @@
 # Copyright (C) 2025 Guillaume Chinal <guiiix@invisiblethingslab.com>
 #
-# This program is free software; you can redistribute it and/or modify
+# This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
+# the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -10,8 +10,8 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License along
-# with this program. If not, see <https://www.gnu.org/licenses/>.
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/plugins/strategy/qubes_proxy.py
+++ b/plugins/strategy/qubes_proxy.py
@@ -1,0 +1,574 @@
+# Copyright (C) 2025 Guillaume Chinal <guiiix@invisiblethingslab.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import fcntl
+import multiprocessing
+import os
+import re
+import shutil
+import tarfile
+import tempfile
+import traceback
+import time
+
+from contextlib import suppress
+from pathlib import Path
+
+import qubesadmin
+import yaml
+
+from ansible import context
+from ansible.executor.play_iterator import PlayIterator
+from ansible.plugins.strategy.linear import StrategyModule as LinearStrategyModule
+from ansible.utils.display import Display
+from ansible.plugins.vars.host_group_vars import VarsModule
+from ansible.parsing.yaml.objects import AnsibleBaseYAMLObject
+
+
+display = Display()
+
+RPC_SYS_POLICY_FILES = (
+    Path("/etc/qubes/policy.d/include/admin-local-rwx"),
+    Path("/etc/qubes/policy.d/include/admin-global-ro"),
+)
+RPC_INCLUDE_POL_FILE = Path("/etc/qubes/policy.d/include/qubes-ansible")
+RPC_ANSIBLE_POL_FILE = Path("/etc/qubes/policy.d/30-qubes-ansible.policy")
+DISPVM_NAME_MAXLEN = 31
+
+
+def run_play_executor(iterator, play_context):
+    return QubesPlayExecutor(iterator, play_context).run()
+
+
+def filter_control_chars(text: bytes):
+    """Filter control chars from bytes, keep only foreground colors"""
+    new_buff = b""
+    while len(text) > 0:
+        # Allow SGR Reset
+        if text[:4] == b"\x1b[0m":
+            new_buff += text[:4]
+            text = text[4:]
+            continue
+
+        # Allow setting foreground colors
+        if (
+                # starts with ESC [ ends with m
+                text[:2] == b"\x1b[" and text[6:7] == b"m" and
+
+                # normal (0), bold (1)
+                text[2] in (0x30, 0x31) and
+
+                # comma
+                text[3] == 0x3B and
+
+                # 30-37
+                text[4] == 0x33 and 0x30 <= text[5] <= 0x37
+        ):
+            new_buff += text[:7]
+            text = text[7:]
+            continue
+
+        # Filter other control chars
+        current_byte = text[:1]
+        if b"\040" <= current_byte <= b"\176" or \
+                current_byte in (b"\a", b"\b", b"\n", b"\r", b"\t"):
+            new_buff += current_byte
+        else:
+            new_buff += b"_"
+        text = text[1:]
+    return new_buff
+
+
+class QubesPlayExecutor:
+    """Run plays on a given host through its management disposable VM"""
+
+    def __init__(self, iterator, play_context):
+        self.app = qubesadmin.Qubes()
+        self.host = iterator._play.hosts[0]
+        self.loader = play_context._loader
+        self.inventory = iterator._variable_manager._inventory
+        self.iterator = iterator
+        self.play = iterator._play
+        self.play_context = play_context
+        self.variable_manager = iterator._variable_manager
+
+        self.dispvm_initially_running = False
+
+        if hasattr(self.host.name, "_strip_unsafe"):
+            self.host_name = self.host.name._strip_unsafe()
+        else:
+            self.host_name = self.host.name
+        self.temp_dir = Path(
+            tempfile.TemporaryDirectory(
+                prefix="qubes-ansible-"
+            ).name
+        )
+        self.vars_plugin = VarsModule()
+        self.vm = None
+
+    @property
+    def dispvm_mgmt_name(self):
+        return f"disp-mgmt-{self.host_name}"[:DISPVM_NAME_MAXLEN]
+
+    def _add_group_vars(self):
+        """Build group variables files
+
+           Dumps group variables this host belongs to using vars plugin and
+           write them to group_vars/<group>.yaml
+        """
+        group_vars_dir = self.temp_dir / "group_vars"
+        group_vars_dir.mkdir()
+        for group_name, group in self.inventory.groups.items():
+            if self.host in group.get_hosts():
+                group_vars = {}
+                for inventory_source in self.inventory._sources:
+                    for (
+                        variable_name,
+                        variable_value,
+                    ) in self.vars_plugin.get_vars(
+                        self.loader, inventory_source, group
+                    ).items():
+                        group_vars[
+                            self.ansible_to_native(variable_name)
+                        ] = self.ansible_to_native(variable_value)
+                if group_vars:
+                    with open(
+                        group_vars_dir / f"{group_name}.yaml", "w"
+                    ) as group_vars_file:
+                        yaml.safe_dump(group_vars, group_vars_file)
+
+    def _add_host_vars(self):
+        """Build host variables files
+
+           We're building a file in host_vars/<host>.yaml containing current
+           host variables. This is done using vars plugin.
+
+           Extra variables (`-e` option) are also added to this file
+        """
+        host_vars_dir = self.temp_dir / "host_vars"
+        host_vars_dir.mkdir()
+        host_vars_file_path = (
+            host_vars_dir / f"{self.host_name}.yaml"
+        )
+        with open(host_vars_file_path, "w") as host_vars_file:
+            host_vars = {}
+            for inventory_source in self.inventory._sources:
+                for (
+                    variable_name,
+                    variable_value,
+                ) in self.vars_plugin.get_vars(
+                    self.loader, inventory_source, self.host
+                ).items():
+                    host_vars[
+                        self.ansible_to_native(variable_name)
+                    ] = self.ansible_to_native(variable_value)
+            # We add extra variables here
+            for (
+                variable_name,
+                variable_value,
+            ) in self.variable_manager.extra_vars.items():
+                host_vars[variable_name] = variable_value
+            yaml.safe_dump(host_vars, host_vars_file)
+
+    def _add_play(self, play):
+        """Builds the playbook that will be executed on DispVM
+
+           :param play: current Play object
+
+           We need to build a YAML file containing only the current play that
+           will be passed to the disposable VM.
+
+           `get_path` method from Ansible Play object is very useful for
+           our needs as this returns the path to the file containing the play
+           and the line at which it is declared.
+
+           We just have to parse this YAML file starting from that line to get
+           the list of remaining plays and keep only the next one (i.e. first
+           of the list).
+        """
+        play_yaml = self._get_first_play_yaml(
+            *play.get_path().split(":")
+        )
+        play_yaml["hosts"] = [self.host_name]
+        play_yaml["strategy"] = "linear"
+        playbook_chunk_path = self.temp_dir / "playbook.yaml"
+        with playbook_chunk_path.open("w") as playbook_chunk_file:
+            yaml.safe_dump([play_yaml], playbook_chunk_file)
+
+    def _add_roles(self, play):
+        """Adds play role
+
+           :param play: current Play object
+
+           We are using `get_roles` method from Ansible internal Play object
+           to check if there are associated roles to the current play.
+           If so, we can get the path to every roles directory using
+           `get_role_path` method.
+
+           Then, we just have to copy every role in a destination "roles"
+           folder
+        """
+        dest_roles_path = self.temp_dir / "roles"
+        dest_roles_path.mkdir()
+
+        for role in play.get_roles():
+            role_path = Path(role.get_role_path())
+            shutil.copytree(
+                role_path, dest_roles_path / role_path.name
+            )
+
+    def _add_rpc_policies(self):
+        src = self.dispvm_mgmt_name
+        dst = self.vm.name
+
+        while True:
+            with RPC_INCLUDE_POL_FILE.open("a+") as pol_file:
+                fcntl.lockf(pol_file.fileno(), fcntl.LOCK_EX)
+                try:
+                    if os.fstat(pol_file.fileno()) != os.stat(
+                        RPC_INCLUDE_POL_FILE
+                    ):
+                        continue
+                except FileNotFoundError:
+                    continue
+
+                pol_file.write(f"{src} {dst} allow target=dom0\n")
+            break
+
+        while True:
+            with RPC_ANSIBLE_POL_FILE.open("a+") as pol_file:
+                fcntl.lockf(pol_file.fileno(), fcntl.LOCK_EX)
+                try:
+                    if os.fstat(pol_file.fileno()) != os.stat(
+                        RPC_ANSIBLE_POL_FILE
+                    ):
+                        continue
+                except FileNotFoundError:
+                    continue
+
+                pol_file.write(
+                    f"qubes.Filecopy       * {src} {dst} allow\n"
+                    f"qubes.WaitForSession * {src} {dst} allow\n"
+                    f"qubes.VMShell        * {src} {dst} allow\n"
+                    f"qubes.VMRootShell    * {src} {dst} allow\n"
+                    f"admin.vm.List        * {src} dom0  allow\n"
+                )
+            break
+
+    @staticmethod
+    def _build_ansible_args():
+        args = []
+        current_args = context.CLIARGS
+
+        verbosity = current_args.get('verbosity')
+        if verbosity:
+            args.append(f"-{'v'*display.verbosity}")
+
+        tags = current_args.get('tags')
+        if tags:
+            for tag in tags:
+                args += ["-t", tag]
+
+        skip_tags = current_args.get('skip_tags')
+        if skip_tags:
+            for tag in skip_tags:
+                args += ["--skip-tags", tag]
+
+        for boolean_arg in ["check", "diff", "force_handlers", "flush_cache"]:
+            if current_args.get(boolean_arg):
+                args.append(f"--{boolean_arg.replace('_', '-')}")
+
+        return args
+
+    def _build_tar(self):
+        tar_file_path = (
+            self.temp_dir.parent / f"{self.temp_dir.name}.tar"
+        )
+        old_path = os.getcwd()
+        os.chdir(self.temp_dir)
+        with tarfile.open(tar_file_path, "w") as tar_file:
+            tar_file.add(".", recursive=True)
+        os.chdir(old_path)
+        return tar_file_path
+
+    @staticmethod
+    def _get_first_play_yaml(path, start_line):
+        with open(path, "r") as playbook_file:
+            return yaml.safe_load(
+                "".join(
+                    playbook_file.readlines()[int(start_line) - 1 :]
+                )
+            )[0]
+
+    def _remove_rpc_policies(self):
+        src = self.dispvm_mgmt_name
+        dst = self.vm.name
+
+        with RPC_INCLUDE_POL_FILE.open("a+") as pol_file:
+            fcntl.lockf(pol_file.fileno(), fcntl.LOCK_EX)
+            with suppress(FileNotFoundError):
+                os.stat(RPC_INCLUDE_POL_FILE)
+                pol_file.seek(0)
+                new_file_lines = [
+                    line
+                    for line in pol_file.readlines()
+                    if not re.match(
+                        rf"^\s*{re.escape(src)}\s+{re.escape(dst)}\s+",
+                        line,
+                    )
+                ]
+            pol_file.seek(0)
+            pol_file.truncate()
+            pol_file.write("".join(new_file_lines))
+            pol_file.flush()
+
+        with RPC_ANSIBLE_POL_FILE.open("a+") as pol_file:
+            fcntl.lockf(pol_file.fileno(), fcntl.LOCK_EX)
+            with suppress(FileNotFoundError):
+                pol_file.seek(0)
+                os.stat(RPC_ANSIBLE_POL_FILE)
+                new_file_lines = [
+                    line
+                    for line in pol_file.readlines()
+                    if not re.match(
+                        rf"^\s*\S+\s+\S+\s+{re.escape(src)}\s+",
+                        line,
+                    )
+                ]
+                pol_file.seek(0)
+                pol_file.truncate()
+                pol_file.write("".join(new_file_lines))
+                pol_file.flush()
+
+    def _start_mgmt_disp_vm(self):
+        self.vvv("Lookup for dispvm_mgmt")
+        dispvm = self.app.domains.get(self.dispvm_mgmt_name)
+        self.vvv(f"Found dispvm: {dispvm}")
+        if dispvm is None:
+            self.vvv(
+                f"Creating dispvm {self.dispvm_mgmt_name}")
+            dispvm = self.app.add_new_vm(
+                "DispVM",
+                template=self.vm.management_dispvm,
+                label=self.vm.management_dispvm.label,
+                name=self.dispvm_mgmt_name,
+            )
+            dispvm.features["internal"] = False
+            dispvm.features["gui"] = False
+            dispvm.netvm = None
+            dispvm.auto_cleanup = True
+        self._dispvm_initially_running = self.vm.is_running()
+        if not dispvm.is_running():
+            dispvm.start()
+        return dispvm
+
+    @staticmethod
+    def ansible_to_native(var):
+        if isinstance(var, AnsibleBaseYAMLObject):
+            return var.__class__.__bases__[1](var)
+        return var
+
+    def run(self):
+        """Runs the given play on the mgmt dispvm of the host"""
+        self.vvv(f"Running play {self.play}")
+        self.vm = self.app.domains.get(self.host_name)
+        if not self.vm:
+            raise KeyError(f"Host {self.host.name} not found")
+        self.vvv(f"Found VM {self.vm}")
+
+        dispvm = self._start_mgmt_disp_vm()
+
+        self._add_rpc_policies()
+        self.temp_dir.mkdir()
+
+        try:
+            self._add_play(self.play)
+            self._add_roles(self.play)
+            self._add_host_vars()
+            self._add_group_vars()
+            tar_file_path = self._build_tar()
+            ansible_args = self._build_ansible_args()
+
+            self.vvv(
+                f"Copying {tar_file_path} to {self.vm}")
+            dispvm.run_service(
+                "qubes.Filecopy",
+                localcmd="/usr/lib/qubes/qfile-dom0-agent {}".format(
+                    tar_file_path
+                ),
+            ).wait()
+
+            self.vvv(
+                f"Running qubes.AnsibleVM on {self.vm}")
+            p = dispvm.run_service("qubes.AnsibleVM")
+            rpc_args = (
+                    tar_file_path.name
+                    + "\n"
+                    + self.host_name
+                    + "\n"
+                    + "\n".join(ansible_args)
+                    + "\n"
+            ).encode()
+            self.vvvv(f"RPC args: {rpc_args}")
+            (untrusted_stdout, untrusted_stderr) = p.communicate(rpc_args)
+            self.vvvv(f"stdout: {untrusted_stdout}")
+            self.vvvv(f"stderr: {untrusted_stderr}")
+            self.vvvv(f"return code: {p.returncode}")
+            return (self.host,
+                    p.returncode,
+                    filter_control_chars(untrusted_stdout).decode("utf-8"),
+                    filter_control_chars(untrusted_stderr).decode("utf-8"),
+                    self.dispvm_mgmt_name,
+                    self.play.name)
+
+        finally:
+            self._remove_rpc_policies()
+            shutil.rmtree(self.temp_dir)
+            if not self.dispvm_initially_running:
+                dispvm.shutdown()
+                while dispvm.is_running():
+                    time.sleep(1)
+                time.sleep(2)
+
+    def _verbose(self, msg: str, level: int):
+        getattr(display, "v" * level)(f"<{self.host_name}> {msg}")
+
+    def v(self, msg):
+        self._verbose(msg, 1)
+
+    def vv(self, msg):
+        self._verbose(msg, 2)
+
+    def vvv(self, msg):
+        self._verbose(msg, 3)
+
+    def vvvv(self, msg):
+        self._verbose(msg, 4)
+
+    def vvvvv(self, msg):
+        self._verbose(msg, 5)
+
+    def vvvvvv(self, msg):
+        self._verbose(msg, 6)
+
+
+class StrategyModule(LinearStrategyModule):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._setup_rpc_policies()
+
+    def _new_play_iterator_with_hosts(
+            self,
+            iterator,
+            play_context,
+            hosts):
+        new_play = iterator._play.copy()
+        new_play.hosts = hosts
+        return PlayIterator(
+            inventory=self._inventory,
+            play=new_play,
+            play_context=play_context,
+            variable_manager=self._variable_manager,
+            all_vars=self._variable_manager.get_vars(play=new_play),
+            start_at_done=self._tqm._start_at_done
+        )
+
+    @staticmethod
+    def _setup_rpc_policies():
+        Path(RPC_INCLUDE_POL_FILE).touch()
+        for policy_file in RPC_SYS_POLICY_FILES:
+            policy_lines = [line.strip() for line in
+                            policy_file.read_text().split("\n")]
+            if "!include include/qubes-ansible" not in policy_lines:
+                with policy_file.open("a") as policy_fd:
+                    policy_fd.write("!include include/qubes-ansible\n")
+
+    @staticmethod
+    def collect_error(error):
+        display.display(f"[ERROR]: {str(error)}", "red")
+        display.display(
+            ''.join(traceback.format_exception(None, error, error.__traceback__))
+            , "red")
+
+    def collect_result(self, result_tuple):
+        host, retcode, stdout, stderr, dispvm, play_name = result_tuple
+        display.banner(
+            f"QUBESOS [{dispvm}: PLAY {play_name}]"
+        )
+        if stderr:
+            display.display(str(stderr), "red")
+        if stdout:
+            display.display(str(stdout), "bright blue")
+        self.qubes_results[host] = retcode
+
+    def proxy_run(self, iterator, play_context):
+        play = iterator._play
+        display.vvv(
+            f"<QubesOS> Running play {play} "
+            f"with {self._tqm._forks} forks")
+        pool = multiprocessing.Pool(self._tqm._forks)
+
+        self.qubes_results = {}
+        for host in self._inventory.get_hosts(play.hosts):
+            self.qubes_results[host] = 255
+
+            new_iterator = self._new_play_iterator_with_hosts(
+                iterator, play_context, [host])
+            pool.apply_async(
+                run_play_executor,
+                (new_iterator, play_context),
+                callback=self.collect_result,
+                error_callback=self.collect_error,
+            )
+        pool.close()
+        pool.join()
+
+        stats = self._tqm._stats
+        for host, result in self.qubes_results.items():
+            if result == 0:
+                stats.increment("ok", host.name)
+            else:
+                stats.increment("failures", host.name)
+
+        return max(self.qubes_results.values())
+
+    def run(self, iterator, play_context):
+        play = iterator._play
+
+        target_hosts = self._inventory.get_hosts(play.hosts)
+        local_hosts = [host for host in target_hosts if host.name == "localhost"]
+        retval_local_exec = self._tqm.RUN_OK
+
+        remote_hosts = [host for host in target_hosts if host.name != "localhost"]
+        retval_remote_exec = self._tqm.RUN_OK
+
+        if local_hosts:
+            retval_local_exec = super().run(
+                self._new_play_iterator_with_hosts(
+                    iterator, play_context, local_hosts),
+                play_context
+            )
+
+        # For other host, we need to start a disp mgmt and run the play inside
+        if remote_hosts:
+            retval_remote_exec = self.proxy_run(
+                self._new_play_iterator_with_hosts(
+                    iterator, play_context, remote_hosts),
+                play_context
+            )
+
+        return max(retval_local_exec, retval_remote_exec)

--- a/qubes-ansible.spec.in
+++ b/qubes-ansible.spec.in
@@ -25,6 +25,8 @@ Requires:      %{name}
 %description dom0
 This package contains the qubes_proxy ansible strategy plugin allowing to run
 Ansible playbooks on dom0 securely by proxifying plays execution on disposables.
+Note that this package edits /etc/ansible/ansible.cfg to set qubes_proxy as the
+default strategy.
 
 
 %package tests
@@ -55,15 +57,24 @@ rm -rf %{buildroot}
 %{__mkdir} -p %{buildroot}%{_datadir}/ansible/plugins/strategy
 %{__mkdir} -p %{buildroot}%{_datadir}/ansible/tests/qubes
 %{__mkdir} -p %{buildroot}%{_sysconfdir}/qubes-rpc/
+%{__mkdir} -p %{buildroot}/usr/lib/qubes/
 
 # Install the qubesos module and qubes connection plugin
 install -m 644 plugins/modules/qubesos.py %{buildroot}%{_datadir}/ansible/plugins/modules/qubesos.py
 install -m 644 plugins/connection/qubes.py %{buildroot}%{_datadir}/ansible/plugins/connection/qubes.py
 install -m 644 plugins/strategy/qubes_proxy.py %{buildroot}%{_datadir}/ansible/plugins/strategy/qubes_proxy.py
 install -m 755 qubes-rpc/qubes.AnsibleVM %{buildroot}%{_sysconfdir}/qubes-rpc/qubes.AnsibleVM
+install -m 755 update-ansible-default-strategy %{buildroot}/usr/lib/qubes/update-ansible-default-strategy
 
 install -m 644 tests/qubes/*.py %{buildroot}%{_datadir}/ansible/tests/qubes/
 install -m 644 tests/ansible.cfg %{buildroot}%{_datadir}/ansible/tests/qubes/
+
+%post dom0
+/usr/lib/qubes/update-ansible-default-strategy
+
+%triggerin dom0 -- ansible
+/usr/lib/qubes/update-ansible-default-strategy
+
 
 %files
 %doc README.md LICENSE EXAMPLES.md
@@ -72,6 +83,7 @@ install -m 644 tests/ansible.cfg %{buildroot}%{_datadir}/ansible/tests/qubes/
 
 %files dom0
 %{_datadir}/ansible/plugins/strategy/qubes_proxy.py
+/usr/lib/qubes/update-ansible-default-strategy
 
 %files tests
 %{_datadir}/ansible/tests/qubes/*.py

--- a/qubes-ansible.spec.in
+++ b/qubes-ansible.spec.in
@@ -17,28 +17,50 @@ to manage QubesOS virtual machines. The files are installed into the Ansible mod
 Ansible can automatically discover and use them. This package is intended to be installed in dom0
 (or a management qube).
 
+
+%package dom0
+Summary:       qubes_proxy ansible strategy to run ansible on dom0 securely
+Requires:      %{name}
+
+%description dom0
+This package contains the qubes_proxy ansible strategy plugin allowing to run
+Ansible playbooks on dom0 securely by proxifying plays execution on disposables.
+
+
 %package tests
-Summary:    Tests for the module and the connection
-Requires:   %{name}
-Requires:   python3-pytest
+Summary:       Tests for the module and the connection
+Requires:      %{name}
+Requires:      python3-pytest
 
 %description tests
 Tests for the module and the connection.
 
+
+%package  vm
+Summary:       qubes-ansible RPC script to run ansible on a disposable VM
+Requires:      %{name}
+
+%description vm
+qubes-ansible RPC script to run ansible on a disposable VM
+
+
 %prep
 %autosetup
 
-%build
 
 %install
 rm -rf %{buildroot}
 %{__mkdir} -p %{buildroot}%{_datadir}/ansible/plugins/modules
 %{__mkdir} -p %{buildroot}%{_datadir}/ansible/plugins/connection
+%{__mkdir} -p %{buildroot}%{_datadir}/ansible/plugins/strategy
 %{__mkdir} -p %{buildroot}%{_datadir}/ansible/tests/qubes
+%{__mkdir} -p %{buildroot}%{_sysconfdir}/qubes-rpc/
 
 # Install the qubesos module and qubes connection plugin
 install -m 644 plugins/modules/qubesos.py %{buildroot}%{_datadir}/ansible/plugins/modules/qubesos.py
 install -m 644 plugins/connection/qubes.py %{buildroot}%{_datadir}/ansible/plugins/connection/qubes.py
+install -m 644 plugins/strategy/qubes_proxy.py %{buildroot}%{_datadir}/ansible/plugins/strategy/qubes_proxy.py
+install -m 755 qubes-rpc/qubes.AnsibleVM %{buildroot}%{_sysconfdir}/qubes-rpc/qubes.AnsibleVM
 
 install -m 644 tests/qubes/*.py %{buildroot}%{_datadir}/ansible/tests/qubes/
 install -m 644 tests/ansible.cfg %{buildroot}%{_datadir}/ansible/tests/qubes/
@@ -48,9 +70,17 @@ install -m 644 tests/ansible.cfg %{buildroot}%{_datadir}/ansible/tests/qubes/
 %{_datadir}/ansible/plugins/modules/qubesos.py
 %{_datadir}/ansible/plugins/connection/qubes.py
 
+%files dom0
+%{_datadir}/ansible/plugins/strategy/qubes_proxy.py
+
 %files tests
 %{_datadir}/ansible/tests/qubes/*.py
 %{_datadir}/ansible/tests/qubes/ansible.cfg
+
+
+%files vm
+%{_sysconfdir}/qubes-rpc/qubes.AnsibleVM
+
 
 %changelog
 @CHANGELOG@

--- a/qubes-ansible.spec.in
+++ b/qubes-ansible.spec.in
@@ -53,6 +53,7 @@ qubes-ansible RPC script to run ansible on a disposable VM
 %install
 rm -rf %{buildroot}
 %{__mkdir} -p %{buildroot}%{_datadir}/ansible/plugins/modules
+%{__mkdir} -p %{buildroot}%{_datadir}/ansible/plugins/callback
 %{__mkdir} -p %{buildroot}%{_datadir}/ansible/plugins/connection
 %{__mkdir} -p %{buildroot}%{_datadir}/ansible/plugins/strategy
 %{__mkdir} -p %{buildroot}%{_datadir}/ansible/tests/qubes
@@ -61,6 +62,7 @@ rm -rf %{buildroot}
 
 # Install the qubesos module and qubes connection plugin
 install -m 644 plugins/modules/qubesos.py %{buildroot}%{_datadir}/ansible/plugins/modules/qubesos.py
+install -m 644 plugins/callback/qubesos_strategy_guard.py %{buildroot}%{_datadir}/ansible/plugins/callback/qubesos_strategy_guard.py
 install -m 644 plugins/connection/qubes.py %{buildroot}%{_datadir}/ansible/plugins/connection/qubes.py
 install -m 644 plugins/strategy/qubes_proxy.py %{buildroot}%{_datadir}/ansible/plugins/strategy/qubes_proxy.py
 install -m 755 qubes-rpc/qubes.AnsibleVM %{buildroot}%{_sysconfdir}/qubes-rpc/qubes.AnsibleVM
@@ -82,6 +84,7 @@ install -m 644 tests/ansible.cfg %{buildroot}%{_datadir}/ansible/tests/qubes/
 %{_datadir}/ansible/plugins/connection/qubes.py
 
 %files dom0
+%{_datadir}/ansible/plugins/callback/qubesos_strategy_guard.py
 %{_datadir}/ansible/plugins/strategy/qubes_proxy.py
 /usr/lib/qubes/update-ansible-default-strategy
 

--- a/qubes-rpc/qubes.AnsibleVM
+++ b/qubes-rpc/qubes.AnsibleVM
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+read -r tar_file
+read -r dst_host
+ansible_args=()
+for i in $(seq 100); do
+  [[ $i == 100 ]] && exit 1
+  read -r item
+  [[ -z "$item" ]] && break
+  ansible_args+=("$item")
+done
+
+temp_dir="$(mktemp -d)"
+
+# shellcheck disable=SC2064
+trap "rm -rf '$temp_dir'" EXIT
+
+tar_file_path="/home/user/QubesIncoming/dom0/${tar_file}"
+[ -f "$tar_file_path" ] || exit 1
+
+tar -C "$temp_dir" -xf "$tar_file_path"
+
+cat << EOF > "${temp_dir}/inventory"
+[appvms]
+${dst_host}
+
+[appvms:vars]
+ansible_connection=qubes
+EOF
+
+ANSIBLE_FORCE_COLOR=True ansible-playbook -i "${temp_dir}/inventory" "${ansible_args[@]}" "${temp_dir}/playbook.yaml"

--- a/update-ansible-default-strategy
+++ b/update-ansible-default-strategy
@@ -1,0 +1,24 @@
+#!/usr/bin/python3
+
+import configparser
+import shutil
+
+from pathlib import Path
+
+CONFIG_FILE = Path("/etc/ansible/ansible.cfg")
+CONFIG_FILE.touch()
+c = configparser.ConfigParser(allow_no_value=True)
+c.read(CONFIG_FILE)
+
+current_val = None
+try:
+    current_val = c.get("defaults", "strategy")
+except configparser.NoSectionError:
+    c.add_section("defaults")
+except configparser.NoOptionError:
+    pass
+
+if current_val != "qubes_proxy":
+    c.set("defaults", "strategy", "qubes_proxy")
+    shutil.copy(CONFIG_FILE, CONFIG_FILE.parent / (CONFIG_FILE.name + ".rpmsave"))
+    c.write(CONFIG_FILE.open("w"))


### PR DESCRIPTION
~This pull request brings a new ``qubes-ansible`` wrapping the  well-known ``ansible-playbook`` command.
The tools allows to run playbooks from dom0 without risking to comprise it.~

This pull request brings a new `qubes_proxy` strategy plugin allowing dom0 to run playbooks on qubes while guaranteeing isolation from untrusted Ansible data.

Implements: https://github.com/QubesOS/qubes-issues/issues/10030

The plugin scans each play’s target hosts:
  - Non‑localhost plays are executed inside a disposable VM having required permissions to manage the target host only, isolating untrusted operations from,
  - Local (localhost) plays are executed directly on dom0 when a task legitimately needs local access.

Option `--forks` can be used to limit parallel VM invocations.