### PR TITLE
Fix qubes_proxy crash if `group_vars` or `host_vars` directory exists

### DIFF
--- a/plugins/strategy/qubes_proxy.py
+++ b/plugins/strategy/qubes_proxy.py
@@ -419,7 +419,6 @@ class QubesPlayExecutor:
             self._add_inventory()
             tar_file_path = self._build_tar()
             ansible_args = self._build_ansible_args()
-            ansible_args += ["-i", f"{self.temp_dir}/inventory"]
 
             self.vvv(
                 f"Copying {tar_file_path} to {self.vm}")

--- a/qubes-rpc/qubes.AnsibleVM
+++ b/qubes-rpc/qubes.AnsibleVM
@@ -20,4 +20,4 @@ tar_file_path="/home/user/QubesIncoming/dom0/${tar_file}"
 
 tar -C "$temp_dir" -xf "$tar_file_path"
 
-ANSIBLE_FORCE_COLOR=True ansible-playbook "${ansible_args[@]}" "${temp_dir}/playbook.yaml"
+ANSIBLE_FORCE_COLOR=True ansible-playbook -i "${temp_dir}/inventory" "${ansible_args[@]}" "${temp_dir}/playbook.yaml"


### PR DESCRIPTION
closes QubesOS/qubes-issues#10208

- Use `DataLoader` as default if `self.loader` is None
- simplified the `group_vars`  loop with `self.host.get_groups()`
  - will include every host in the `all` group (previous not the case and a bug)
- use  `AnsibleDumper` to dump YAML files for `group_vars` and `host_vars`
- dynamic creation of `inventory` to support `group_vars`  on DispVM
