### PR TITLE
fix for cloning AppVM (vmtype) with AppVM as Template

### DIFF
--- a/plugins/modules/qubesos.py
+++ b/plugins/modules/qubesos.py
@@ -419,9 +419,14 @@ class QubesVirt(object):
         else:
             network_vm = self.get_vm(netvm)
         if vmtype == "AppVM":
-            vm = self.app.add_new_vm(
-                vmtype, vmname, label, template=template_vm
-            )
+            if self.get_vm(template_vm)._klass != "AppVM":
+                vm = self.app.add_new_vm(
+                    vmtype, vmname, label, template=template_vm
+                )
+            else:
+                self.app.clone_vm(
+                    template_vm, vmname, vmtype, ignore_devices=True
+                )
             vm.netvm = network_vm
         elif vmtype in ["StandaloneVM", "TemplateVM"] and template_vm:
             vm = self.app.clone_vm(

--- a/plugins/modules/qubesos.py
+++ b/plugins/modules/qubesos.py
@@ -419,13 +419,13 @@ class QubesVirt(object):
         else:
             network_vm = self.get_vm(netvm)
         if vmtype == "AppVM":
-            if template_vm == "" or self.get_vm(template_vm)._klass != "AppVM":
-                vm = self.app.add_new_vm(
-                    vmtype, vmname, label, template=template_vm
-                )
-            else:
+            if template_vm and self.get_vm(template_vm)._klass == vmtype:
                 vm = self.app.clone_vm(
                     template_vm, vmname, vmtype, ignore_devices=True
+                )
+            else:
+                vm = self.app.add_new_vm(
+                    vmtype, vmname, label, template=template_vm
                 )
             vm.netvm = network_vm
         elif vmtype in ["StandaloneVM", "TemplateVM"] and template_vm:

--- a/plugins/modules/qubesos.py
+++ b/plugins/modules/qubesos.py
@@ -424,7 +424,7 @@ class QubesVirt(object):
                     vmtype, vmname, label, template=template_vm
                 )
             else:
-                self.app.clone_vm(
+                vm = self.app.clone_vm(
                     template_vm, vmname, vmtype, ignore_devices=True
                 )
             vm.netvm = network_vm

--- a/plugins/modules/qubesos.py
+++ b/plugins/modules/qubesos.py
@@ -419,7 +419,7 @@ class QubesVirt(object):
         else:
             network_vm = self.get_vm(netvm)
         if vmtype == "AppVM":
-            if self.get_vm(template_vm)._klass != "AppVM":
+            if template_vm == "" or self.get_vm(template_vm)._klass != "AppVM":
                 vm = self.app.add_new_vm(
                     vmtype, vmname, label, template=template_vm
                 )

--- a/tests/qubes/test_module.py
+++ b/tests/qubes/test_module.py
@@ -90,6 +90,9 @@ def test_lifecycle_status_reporting(qubes, vmname, request):
 
 def test_create_clone_vmtype_combinations(qubes, vmname, request):
     request.node.mark_vm_created(vmname)
+    request.node.mark_vm_created(f"{vmname}-clone-appvm")
+    #request.node.mark_vm_created(f"{vmname}-clone-templatevm")
+    #request.node.mark_vm_created(f"{vmname}-clone-standalonevm")
 
     # Test creating / cloning from AppVM
     core(Module({"command": "create", "name": vmname, "vmtype": "AppVM"}))
@@ -105,12 +108,6 @@ def test_create_clone_vmtype_combinations(qubes, vmname, request):
     #rc, _ = core(Module({"command": "create", "name": f"{vmname}-clone-standalonevm", "template": vmname, "vmtype": "StandaloneVM"}))
     #assert rc == VIRT_SUCCESS
     #assert f"{vmname}-clone-standalonevm" in qubes.domains
-
-    # Cleanup
-    core(Module({"state": "absent", "name": f"{vmname}-clone-appvm"}))
-    #core(Module({"state": "absent", "name": f"{vmname}-clone-templatevm"}))
-    #core(Module({"state": "absent", "name": f"{vmname}-clone-standalonevm"}))
-    core(Module({"state": "absent", "name": vmname}))
 
     # Test creating / cloning from TemplateVM
     core(Module({"command": "create", "name": vmname, "vmtype": "TemplateVM"}))
@@ -129,12 +126,6 @@ def test_create_clone_vmtype_combinations(qubes, vmname, request):
     # assert rc == VIRT_SUCCESS
     # assert f"{vmname}-clone-standalonevm" in qubes.domains
     # 
-    # Cleanup
-    core(Module({"state": "absent", "name": f"{vmname}-clone-appvm"}))
-    # core(Module({"state": "absent", "name": f"{vmname}-clone-templatevm"}))
-    # core(Module({"state": "absent", "name": f"{vmname}-clone-standalonevm"}))
-    core(Module({"state": "absent", "name": vmname}))
-    # 
     # # Test creating / cloning from StandaloneVM
     # core(Module({"command": "create", "name": vmname, "vmtype": "StandaloneVM"}))
     # rc, _ = core(Module({"command": "create", "name": f"{vmname}-clone-appvm", "template": vmname, "vmtype": "AppVM"}))
@@ -149,11 +140,11 @@ def test_create_clone_vmtype_combinations(qubes, vmname, request):
     # assert rc == VIRT_SUCCESS
     # assert f"{vmname}-clone-standalonevm" in qubes.domains
     # 
-    # # Cleanup
-    # core(Module({"state": "absent", "name": f"{vmname}-clone-appvm"}))
+    # Cleanup
+    core(Module({"state": "absent", "name": f"{vmname}-clone-appvm"}))
     # core(Module({"state": "absent", "name": f"{vmname}-clone-templatevm"}))
     # core(Module({"state": "absent", "name": f"{vmname}-clone-standalonevm"}))
-    # core(Module({"state": "absent", "name": vmname}))
+    core(Module({"state": "absent", "name": vmname}))
 
 
 def test_volumes_list_for_standalonevm(qubes, vmname, request):

--- a/tests/qubes/test_module.py
+++ b/tests/qubes/test_module.py
@@ -88,6 +88,73 @@ def test_lifecycle_status_reporting(qubes, vmname, request):
 
     core(Module({"state": "absent", "name": vmname}))
 
+def test_create_clone_vmtype_combinations(qubes, vmname, request):
+    request.node.mark_vm_created(vmname)
+
+    # Test creating / cloning from AppVM
+    core(Module({"command": "create", "name": vmname, "vmtype": "AppVM"}))
+    rc, _ = core(Module({"command": "create", "name": f"{vmname}-clone-appvm", "template": vmname, "vmtype": "AppVM"}))
+
+    assert rc == VIRT_SUCCESS
+    assert f"{vmname}-clone-appvm" in qubes.domains
+
+    #rc, _ = core(Module({"command": "create", "name": f"{vmname}-clone-templatevm", "template": vmname, "vmtype": "TemplateVM"}))
+    #assert rc == VIRT_SUCCESS
+    #assert f"{vmname}-clone-templatevm" in qubes.domains
+
+    #rc, _ = core(Module({"command": "create", "name": f"{vmname}-clone-standalonevm", "template": vmname, "vmtype": "StandaloneVM"}))
+    #assert rc == VIRT_SUCCESS
+    #assert f"{vmname}-clone-standalonevm" in qubes.domains
+
+    # Cleanup
+    core(Module({"state": "absent", "name": f"{vmname}-clone-appvm"}))
+    #core(Module({"state": "absent", "name": f"{vmname}-clone-templatevm"}))
+    #core(Module({"state": "absent", "name": f"{vmname}-clone-standalonevm"}))
+    core(Module({"state": "absent", "name": vmname}))
+
+    # Test creating / cloning from TemplateVM
+    core(Module({"command": "create", "name": vmname, "vmtype": "TemplateVM"}))
+    rc, _ = core(Module({"command": "create", "name": f"{vmname}-clone-appvm", "template": vmname, "vmtype": "AppVM"}))
+    
+    assert rc == VIRT_SUCCESS
+    assert f"{vmname}-clone-appvm" in qubes.domains
+    # 
+    # rc, _ = core(Module({"command": "create", "name": f"{vmname}-clone-templatevm", "template": vmname, "vmtype": "TemplateVM"}))
+    # 
+    # assert rc == VIRT_SUCCESS
+    # assert f"{vmname}-clone-templatevm" in qubes.domains
+    # 
+    # rc, _ = core(Module({"command": "create", "name": f"{vmname}-clone-standalonevm", "template": vmname, "vmtype": "StandaloneVM"}))
+    # 
+    # assert rc == VIRT_SUCCESS
+    # assert f"{vmname}-clone-standalonevm" in qubes.domains
+    # 
+    # Cleanup
+    core(Module({"state": "absent", "name": f"{vmname}-clone-appvm"}))
+    # core(Module({"state": "absent", "name": f"{vmname}-clone-templatevm"}))
+    # core(Module({"state": "absent", "name": f"{vmname}-clone-standalonevm"}))
+    core(Module({"state": "absent", "name": vmname}))
+    # 
+    # # Test creating / cloning from StandaloneVM
+    # core(Module({"command": "create", "name": vmname, "vmtype": "StandaloneVM"}))
+    # rc, _ = core(Module({"command": "create", "name": f"{vmname}-clone-appvm", "template": vmname, "vmtype": "AppVM"}))
+    # assert rc == VIRT_SUCCESS
+    # assert f"{vmname}-clone-appvm" in qubes.domains
+    # 
+    # rc, _ = core(Module({"command": "create", "name": f"{vmname}-clone-templatevm", "template": vmname, "vmtype": "TemplateVM"}))
+    # assert rc == VIRT_SUCCESS
+    # assert f"{vmname}-clone-templatevm" in qubes.domains
+    # 
+    # rc, _ = core(Module({"command": "create", "name": f"{vmname}-clone-standalonevm", "template": vmname, "vmtype": "StandaloneVM"}))
+    # assert rc == VIRT_SUCCESS
+    # assert f"{vmname}-clone-standalonevm" in qubes.domains
+    # 
+    # # Cleanup
+    # core(Module({"state": "absent", "name": f"{vmname}-clone-appvm"}))
+    # core(Module({"state": "absent", "name": f"{vmname}-clone-templatevm"}))
+    # core(Module({"state": "absent", "name": f"{vmname}-clone-standalonevm"}))
+    # core(Module({"state": "absent", "name": vmname}))
+
 
 def test_volumes_list_for_standalonevm(qubes, vmname, request):
     request.node.mark_vm_created(vmname)


### PR DESCRIPTION
closes QubesOS/qubes-issues#9933

---

This is a potential fix QubesOS/qubes-issues#9933

If an `vmtype` is "AppVM" and the `template` is also an AppVM `app.add_new_vm` will cause a crash. 

The fix will use `clone_vm` under this specific condition.

---

Maybe the `create` function could be generalized by do a check between `vmtype` and the real class of the template_vm.

Here is a Table for all combination

| Vmtype|Template VM|Action|
|-|-|-|
| AppVM | AppVM | Clone
| AppVM | Template | CreateVM
| AppVM | StandaloneVM | Error?
| Template | AppVM | Error?
| Template | Template | Clone
| Template | StandaloneVM | Error?
| StandaloneVM | AppVM | Clone?
| StandaloneVM | Template | CreateVM
| StandaloneVM | StandaloneVM | Clone

So if `vmtype` and `template` are the same class it is always a clone. Otherwise if an Template is involved it is CreateVM.

I noticed that https://github.com/QubesOS/qubes-issues/issues/9932 mentioned a similiar issue with vmtype TemplateVM and  template class is TemplateVM. Maybe this could also be fixed by this approach.