### PR TITLE
rework on host vars, tests, and guard improvements 

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,8 @@ lint:
     # install dependencies
     - sudo qubes-dom0-update -y ansible python3-pytest python3-coverage perl-Digest-SHA
     # install from artifacts
-    - find $CI_PROJECT_DIR/artifacts/repository -name '*.noarch.rpm' -exec sudo dnf install -y {} \+
+    - find $CI_PROJECT_DIR/artifacts/repository/host-fc* -name '*.noarch.rpm' -exec sudo dnf install -y {} \+
+    - $CI_PROJECT_DIR/ci/install_ansible_vm.sh
   script:
     # run ansible's tests
     - cd /usr/share/ansible && sudo coverage run --data-file=$CI_PROJECT_DIR/.coverage --include=plugins/modules/qubesos.py,plugins/connection/qubes.py -m pytest -vvv tests/qubes/
@@ -31,5 +32,6 @@ r4.3:mgmt-host:
   extends: .mgmt-host-template
   needs:
     - r4.3:build:host-fc41
+    - r4.3:build:vm-fc42
   variables:
     VM_IMAGE: qubes_4.3_64bit_stable.qcow2

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ install-dom0:
 install-tests:
 	mkdir -p $(DESTDIR)/usr/share/ansible/tests/qubes
 	install -m 644 tests/qubes/*.py $(DESTDIR)/usr/share/ansible/tests/qubes/
-	install -m 644 tests/ansible.cfg $(DESTDIR)/usr/share/ansible/tests/qubes/
+	install -m 644 tests/*.cfg $(DESTDIR)/usr/share/ansible/tests/
 
 install-vm:
 	mkdir -p $(DESTDIR)/etc/qubes-rpc/

--- a/README.md
+++ b/README.md
@@ -22,9 +22,14 @@ This strategy plugin must be used when Ansible is running on dom0 to prevent any
 security issue. The plugin acts as a router which will proxify play execution for a 
 given qube into its management disposable VM.
 
+Technically, the plugin builds an extract of the running playbook, extract host variables and roles
+and run `ansible-playbook` on the management disposable.
+
+
 Using this plugin ensures dom0 isolation from untrusted Ansible data (see https://github.com/QubesOS/qubes-issues/issues/10030).
 
-__NOTE__ - this strategy is set as the default on dom0.
+__NOTE__ - this strategy is set as the default on dom0. Switching to another strategy 
+will raise an error and interrupt Ansible execution.
 
 ## Installation
 
@@ -34,8 +39,8 @@ Install the following package: ``qubes-ansible-dom0``
 
 ### Management DVM
 
-The package ``qubes-ansible-vm`` must be installed on templates used by your qubes management DVM 
-(``default-mgmt-dvm`` by default).
+The package ``qubes-ansible-vm`` (``qubes-ansible`` for Debian and Archlinux) must be installed 
+on templates used by your qubes management DVM (``default-mgmt-dvm`` by default).
 
 ## Usage
 
@@ -45,7 +50,60 @@ in your playbooks and:
   - run the play locally when ``localhost`` is present in the list (dom0 management / ``qubesos`` module usage)
   - proxify play execution through the target disposable management VM that will automatically use the ``qubes`` connection plugin to run the tasks on the target
 
+Using a custom `ansible.cfg` file may override Ansible strategy to `linear` would be detected 
+by the `qubesos_strategy_guard` callback and would cause Ansible to stop. If using such file, 
+add the following setting to ensure `qubes_proxy` strategy is used:
+```
+[defaults]
+strategy=qubes_proxy
+```
+
+You can also put this line in your Play declaration:
+```
+strategy: qubes_proxy
+```
+
+If extra files need to be present on the disposable VM to execute the playbook, you will need
+to place those files in a role and call the role in your play using the `roles` keyword:
+```
+- hosts: work
+  connection: qubes
+  strategy: qubes_proxy
+  roles:
+  - my_role_which_will_copy_files_to_work
+```
+
+The repository structure should look the following:
+
+```
+ansible
+|    playbook.yml
+|    inventory
+└─── roles
+     └─── my_role_which_will_copy_files_to_work
+          └── tasks
+              └── main.yml
+          └── files
+              └── file_to_copy_to_work.txt    
+```
+
+
 See the [examples](EXAMPLES.md) for sample playbooks and role tasks demonstrating common usage scenarios.
+
+## Limitations
+
+The proxy plugin may modify the behaviour of your playbooks. Please notice the following indications and 
+limitations:
+* **Access to facts and variables from other hosts is not possible**: the proxy strategy builds a single
+  host vars file containing a merged view of the target's host variables (i.e., variables issued from command line, group vars, host vars, inventory...).
+  Therefore, attempting to access a variable not directly associated with that host will not work as it will
+  not be present in the merged view.
+* **Extra files may not be copied to the disposable VM**: the proxy plugin does not parse playbooks tasks so
+  it has no idea which file needs to be copied to the disposable. However, play roles are copied to the dispvm.
+* **Tasks executions are not synchronous but Play execution are**: behavious should be almost the same as the [free strategy](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/free_strategy.html).
+* **Disposables output is not parsed**:
+  * Play recap will reflect the number of plays ran for each host instead of the number of tasks
+  * Only plain text output is supported
 
 ## License
 

--- a/ci/install_ansible_vm.sh
+++ b/ci/install_ansible_vm.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+
+function err_ex() {
+    echo "$1" >&2
+    exit 1
+}
+
+default_mgmt_dispvm="$(qubes-prefs management_dispvm)"
+default_mgmt_dispvm_template="$(qvm-prefs "$default_mgmt_dispvm" template)"
+[[ "$default_mgmt_dispvm_template" == fedora-* ]] || err_ex "unsupported template $default_mgmt_dispvm_template"
+fedora_ver="$(echo "$default_mgmt_dispvm_template" | cut -d- -f2)"
+
+repo_dir="artifacts/repository/vm-fc${fedora_ver}"
+[[ -d "$repo_dir" ]] || err_ex "'$repo_dir' not found"
+
+find $repo_dir -name 'qubes-ansible-*.noarch.rpm' \
+    -not -name  'qubes-ansible-dom0*.noarch.rpm' \
+    -not -name  'qubes-ansible-tests*.noarch.rpm' \
+    -exec qvm-copy-to-vm "$default_mgmt_dispvm_template" "{}" \;
+
+qvm-run --pass-io "$default_mgmt_dispvm_template" "sudo dnf install -y /home/user/QubesIncoming/dom0/*.rpm"
+qvm-shutdown --wait "$default_mgmt_dispvm_template"

--- a/plugins/callback/qubesos_strategy_guard.py
+++ b/plugins/callback/qubesos_strategy_guard.py
@@ -15,7 +15,42 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+
+import sys
+
 from ansible.plugins.callback import CallbackBase
+
+
+DOCUMENTATION = r"""
+name: qubesos_strategy_guard
+type: aggregate
+short_description: Ensures qubes_proxy is used in conjunction with qubes connection
+description:
+  - Stops the execution of the playbook when qubes_proxy is not used with qubes connection.
+options:
+  qubes_allow_insecure:
+    description: Do not block playbook execution when qubes connection is used without qubes_proxy
+    type: bool
+    default: false
+    ini:
+      - section: qubesos_strategy_guard
+        key: qubes_allow_insecure
+    env:
+      - name: QUBES_ALLOW_INSECURE
+    vars:
+      - name: qubes_allow_insecure
+  qubes_insecure_quiet:
+    description: Do not print any warning message when qubes_allow_insecure is enabled
+    type: bool
+    default: false
+    ini:
+      - section: qubesos_strategy_guard
+        key: qubes_insecure_quiet
+    env:
+      - name: QUBES_INSECURE_QUIET
+    vars:
+      - name: qubes_insecure_quiet
+"""
 
 
 class CallbackModule(CallbackBase):
@@ -25,25 +60,46 @@ class CallbackModule(CallbackBase):
 
     def v2_playbook_on_play_start(self, play):
         self._play = play
+        self._variable_manager = play.get_variable_manager()
 
     def v2_runner_on_start(self, host, task):
         if self._play.strategy == "qubes_proxy":
             return
 
-        if task._variable_manager is None:
+        qubes_allow_insecure = self.get_option("qubes_allow_insecure")
+        qubes_insecure_quiet = self.get_option("qubes_insecure_quiet")
+        if qubes_allow_insecure and qubes_insecure_quiet:
             return
 
-        task_connection = task._variable_manager.get_vars(
+        if self._variable_manager is None:
+            self._display.vvv(
+                f"{self.CALLBACK_NAME}: Unable to retrieve VariableManager..."
+            )
+            return
+
+        # see TaskExecutor._execute()
+        current_connection = self._variable_manager.get_vars(
             play=self._play,
             host=host,
             task=task,
             include_hostvars=True,
             include_delegate_to=True,
-        ).get("ansible_connection")
+        ).get("ansible_connection", task.connection)
 
-        if task_connection == "qubes":
-            self._display.warning(
-                "Using qubes connection plugin without qubes_proxy strategy is "
-                "considered insecure and may lead to dom0 compromise. Continue "
-                "at your own risk."
+        if current_connection == "qubes":
+            msg = (
+                '\033[22mUsing "qubes" connection plugin without "qubes_proxy" '
+                "strategy is considered insecure and may lead to dom0 "
+                "compromise.\n"
+                "\033[22mTo fix this issue, you can add "
+                "\033[1mstrategy: qubes_proxy\033[22m in your play or add the "
+                'following setting in your "ansible.cfg" file:\n'
+                "\033[1m[defaults]\n\033[1mstrategy=qubes_proxy\033[22m"
             )
+            if self.get_option("qubes_allow_insecure"):
+                self._display.warning(
+                    msg + "\n\033[22mContinue at your own risk.", formatted=True
+                )
+            else:
+                self._display.error(msg, wrap_text=False)
+                sys.exit(1)

--- a/plugins/connection/qubes.py
+++ b/plugins/connection/qubes.py
@@ -98,7 +98,13 @@ class Connection(ConnectionBase):
         if not cmd.endswith("\n"):
             cmd += "\n"
 
-        local_cmd = ["qvm-run", "--pass-io", "--service", self._remote_vmname]
+        local_cmd = [
+            "qvm-run",
+            "--no-gui",
+            "--pass-io",
+            "--service",
+            self._remote_vmname,
+        ]
         # The Ansible module framework catches invalid remote_user values
         if self.user == "root":
             local_cmd.append("qubes.VMRootShell")
@@ -173,6 +179,7 @@ class Connection(ConnectionBase):
         cmd_args = [
             "qvm-run",
             "--pass-io",
+            "--no-gui",
             self._remote_vmname,
             f"cat {in_path}",
         ]

--- a/plugins/strategy/qubes_proxy.py
+++ b/plugins/strategy/qubes_proxy.py
@@ -237,7 +237,12 @@ class QubesPlayExecutor:
         play_yaml["strategy"] = "linear"
         playbook_chunk_path = self.temp_dir / "playbook.yaml"
         with playbook_chunk_path.open("w") as playbook_chunk_file:
-            yaml.safe_dump([play_yaml], playbook_chunk_file)
+            yaml.dump(
+                [play_yaml],
+                playbook_chunk_file,
+                Dumper=AnsibleDumper,
+                default_flow_style=False,
+            )
 
     def _add_inventory(self):
         """Build pseudo inventory for DispVM

--- a/plugins/strategy/qubes_proxy.py
+++ b/plugins/strategy/qubes_proxy.py
@@ -303,6 +303,10 @@ class QubesPlayExecutor:
                     continue
 
                 pol_file.write(f"{src} {dst} allow target=dom0\n")
+                try:
+                    shutil.chown(RPC_INCLUDE_POL_FILE, group="qubes")
+                except PermissionError:
+                    pass
             break
 
         while True:
@@ -323,6 +327,10 @@ class QubesPlayExecutor:
                     f"qubes.VMRootShell    * {src} {dst} allow\n"
                     f"admin.vm.List        * {src} dom0  allow\n"
                 )
+                try:
+                    shutil.chown(RPC_ANSIBLE_POL_FILE, group="qubes")
+                except PermissionError:
+                    pass
             break
 
     @staticmethod

--- a/rpm_spec/qubes-ansible.spec.in
+++ b/rpm_spec/qubes-ansible.spec.in
@@ -74,7 +74,7 @@ make DESTDIR=$RPM_BUILD_ROOT install-all
 
 %files tests
 %{_datadir}/ansible/tests/qubes/*.py
-%{_datadir}/ansible/tests/qubes/ansible.cfg
+%{_datadir}/ansible/tests/*.cfg
 
 
 %files vm

--- a/tests/ansible_guard_off.cfg
+++ b/tests/ansible_guard_off.cfg
@@ -1,0 +1,2 @@
+[qubesos_strategy_guard]
+qubes_allow_insecure=true

--- a/tests/ansible_guard_quiet.cfg
+++ b/tests/ansible_guard_quiet.cfg
@@ -1,7 +1,3 @@
-[defaults]
-stdout_callback = json
-strategy = linear
-
 [qubesos_strategy_guard]
 qubes_allow_insecure=true
 qubes_insecure_quiet=true

--- a/tests/ansible_linear_strategy.cfg
+++ b/tests/ansible_linear_strategy.cfg
@@ -1,0 +1,3 @@
+[defaults]
+stdout_callback = json
+strategy = linear

--- a/tests/ansible_proxy_strategy.cfg
+++ b/tests/ansible_proxy_strategy.cfg
@@ -1,2 +1,3 @@
 [defaults]
+strategy = qubes_proxy
 stdout_callback = json

--- a/tests/qubes/test_proxy.py
+++ b/tests/qubes/test_proxy.py
@@ -1,0 +1,415 @@
+import pytest
+import shutil
+import subprocess
+import yaml
+
+from configparser import ConfigParser
+from pathlib import Path
+from typing import List, Optional
+
+from ansible.executor.task_queue_manager import TaskQueueManager
+from ansible.module_utils.common.collections import ImmutableDict
+from ansible.inventory.manager import InventoryManager
+from ansible.parsing.dataloader import DataLoader
+from ansible.playbook.play import Play
+from ansible.plugins.callback import CallbackBase
+from ansible.plugins.loader import strategy_loader
+from ansible.vars.manager import VariableManager
+from ansible import context
+from ansible.plugins.strategy.linear import (
+    StrategyModule as LinearStrategyModule,
+)
+from unittest.mock import Mock
+
+
+PLUGIN_PATH = Path(__file__).parent.parent / "plugins" / "modules"
+
+
+class ResultsCollectorJSONCallback(CallbackBase):
+    """A sample callback plugin used for performing an action as results come in.
+
+    If you want to collect all results into a single object for processing at
+    the end of the execution, look into utilizing the ``json`` callback plugin
+    or writing your own custom callback plugin.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(ResultsCollectorJSONCallback, self).__init__(*args, **kwargs)
+        self.host_ok = {}
+        self.host_unreachable = {}
+        self.host_failed = {}
+
+    def v2_runner_on_unreachable(self, result):
+        host = result._host
+        self.host_unreachable[host.get_name()] = result
+
+    def v2_runner_on_ok(self, result, *args, **kwargs):
+        host = result._host
+        self.host_ok[host.get_name()] = result
+
+    def v2_runner_on_failed(self, result, *args, **kwargs):
+        host = result._host
+        self.host_failed[host.get_name()] = result
+
+
+@pytest.fixture
+def run_playbook(tmp_path):
+
+    def _run(
+        playbook: dict,
+        inventory_format: str = "ini",
+        inventory: Optional[dict] = None,
+        host_vars: Optional[dict] = None,
+        group_vars: Optional[dict] = None,
+        extra_args: Optional[List[str]] = None,
+    ):
+
+        cmd = [
+            "ansible-playbook",
+            "-M",
+            str(PLUGIN_PATH),
+        ]
+
+        shutil.copy(
+            Path(__file__).parent.parent / "ansible_proxy_strategy.cfg",
+            tmp_path / "ansible.cfg",
+        )
+
+        if inventory:
+            if inventory_format == "ini":
+                inventory_path = tmp_path / "inventory"
+
+                inventory_content = ConfigParser(allow_no_value=True)
+                for section, section_content in inventory.items():
+                    inventory_content.add_section(section)
+                    for entry in section_content:
+                        inventory_content.set(section, *entry)
+                cmd += ["-i", inventory_path]
+
+                with open(inventory_path, "w") as inventory_file:
+                    inventory_content.write(
+                        inventory_file, space_around_delimiters=False
+                    )
+            elif inventory_format == "yaml":
+                inventory_path = tmp_path / "inventory.yaml"
+                with open(inventory_path, "w") as inventory_file:
+                    yaml.safe_dump(inventory, inventory_file)
+                cmd += ["-i", inventory_path]
+        else:
+            cmd += ["-i", "localhost"]
+
+        playbook_file = tmp_path / "playbook.yaml"
+        playbook_file.write_text(yaml.safe_dump(playbook))
+
+        def _write_inventory_vars(inventory_vars, dir_name):
+            if inventory_vars:
+                vars_dir = tmp_path / dir_name
+                vars_dir.mkdir()
+
+                for file_name, content in inventory_vars.items():
+                    (vars_dir / f"{file_name}.yaml").write_text(
+                        yaml.safe_dump(content)
+                    )
+
+        _write_inventory_vars(host_vars, "host_vars")
+        _write_inventory_vars(group_vars, "group_vars")
+
+        if extra_args:
+            cmd += extra_args
+        cmd += [playbook_file]
+
+        result = subprocess.run(
+            cmd,
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+        )
+        return result
+
+    return _run
+
+
+def test_proxy_with_simple_local_playbook(run_playbook):
+    playbook = [{"hosts": "localhost", "tasks": [{"debug": {"msg": "foo"}}]}]
+    result = run_playbook(playbook)
+    assert result.returncode == 0, result.stderr
+    assert (
+        "Could not match supplied host pattern" not in result.stderr
+    ), result.stderr
+
+
+def test_proxy_with_target_appvm(run_playbook, vm):
+    playbook = [{"hosts": vm.name, "tasks": [{"debug": {"msg": "foo"}}]}]
+
+    inventory = {"appvms": [[vm.name]]}
+
+    result = run_playbook(playbook, inventory=inventory)
+    assert result.returncode == 0, result.stderr
+    assert (
+        "Could not match supplied host pattern" not in result.stderr
+    ), result.stderr
+
+
+def test_proxy_with_variables(run_playbook, vm):
+    playbook = [
+        {
+            "hosts": vm.name,
+            "tasks": [
+                {
+                    "fail": {"msg": "undefined var {{ item }}"},
+                    "when": "lookup('vars', item) is undefined",
+                    "loop": [
+                        "host_var_1",
+                        "host_var_2",
+                        "appvm_var",
+                        "my_group_var",
+                    ],
+                }
+            ],
+        }
+    ]
+
+    inventory = {
+        "appvms": [[vm.name]],
+        "appvms:vars": [["appvm_var", "foo"]],
+        "my_group": [[vm.name]],
+        "my_group:vars": [["my_group_var", "foo"]],
+        "all": [
+            [f"{vm.name} host_var_1", "foo"],
+            [f"{vm.name} host_var_2", "bar"],
+        ],
+    }
+
+    result = run_playbook(playbook, inventory=inventory)
+    assert result.returncode == 0, result.stderr
+    assert (
+        "Could not match supplied host pattern" not in result.stderr
+    ), result.stderr
+
+
+def test_proxy_with_dynamic_inventory(run_playbook, vm):
+    playbook = [
+        {
+            "hosts": "localhost",
+            "tasks": [{"add_host": {"name": vm.name, "group": "my_group"}}],
+        },
+        {
+            "hosts": vm.name,
+            "tasks": [
+                {
+                    "fail": {"msg": "undefined var {{ item }}"},
+                    "when": "lookup('vars', item) is undefined",
+                    "loop": [
+                        "my_group_var",
+                    ],
+                }
+            ],
+        },
+    ]
+
+    inventory = {
+        "appvms": [[vm.name]],
+        "appvms:vars": [["appvm_var", "foo"]],
+        "my_group": [],
+        "my_group:vars": [["my_group_var", "foo"]],
+        "all": [
+            [f"{vm.name} host_var_1", "foo"],
+            [f"{vm.name} host_var_2", "bar"],
+        ],
+    }
+
+    result = run_playbook(playbook, inventory=inventory)
+    assert result.returncode == 0, result.stderr
+    assert (
+        "Could not match supplied host pattern" not in result.stderr
+    ), result.stderr
+
+
+def test_proxy_routing(monkeypatch):
+    hosts = ["work", "work2", "localhost", "work3"]
+    sources = ",".join(hosts)
+    if len(hosts) == 1:
+        sources += ","
+    context.CLIARGS = ImmutableDict(
+        connection="smart",
+        module_path=["/to/mymodules", "/usr/share/ansible"],
+        forks=10,
+        become=None,
+        become_method=None,
+        become_user=None,
+        check=False,
+        diff=False,
+    )
+    loader = DataLoader()
+    results_callback = ResultsCollectorJSONCallback()
+    inventory = InventoryManager(loader=loader, sources=sources)
+    variable_manager = VariableManager(loader=loader, inventory=inventory)
+    tqm = TaskQueueManager(
+        inventory=inventory,
+        variable_manager=variable_manager,
+        loader=loader,
+        passwords={},
+        stdout_callback=results_callback,
+        # Use our custom callback instead of the ``default`` callback plugin, which prints to stdout
+    )
+
+    play_source = {
+        "name": "Simple Play",
+        "hosts": hosts,
+        "gather_facts": "no",
+        "strategy": "qubes_proxy",
+        "tasks": [
+            {
+                "action": {
+                    "module": "command",
+                    "args": {"cmd": "/usr/bin/uptime"},
+                }
+            }
+        ],
+    }
+
+    # required to be set for strategy_loader
+    tqm._workers = None
+    strategy = strategy_loader.get("qubes_proxy", tqm=tqm)
+    assert strategy is not None
+
+    calls = {}
+
+    def fake_proxy_run(iterator, play_context):
+        for host in iterator._play.hosts:
+            calls.setdefault(str(host), 0)
+            calls[str(host)] += 1
+        return 0
+
+    strategy.proxy_run = fake_proxy_run
+    fake_linear_run = Mock()
+    fake_linear_run.return_value = 0
+    LinearStrategyModule.run = fake_linear_run
+
+    fake_get_strategy = Mock()
+    fake_get_strategy.return_value = strategy
+    monkeypatch.setattr(strategy_loader, "get", fake_get_strategy)
+
+    play = Play().load(
+        play_source, variable_manager=variable_manager, loader=loader
+    )
+    tqm.run(play)
+
+    assert calls == {"work": 1, "work2": 1, "work3": 1}
+
+    fake_get_strategy.assert_called_once()
+    fake_linear_run.assert_called_once()
+
+
+def test_proxy_with_mixed_variables_sources(run_playbook, vm):
+    playbook = [
+        {
+            "hosts": vm.name,
+            "tasks": [
+                {
+                    "fail": {"msg": "undefined var {{ item }}"},
+                    "when": "lookup('vars', item) is undefined",
+                    "loop": [
+                        "var_1",
+                        "var_2",
+                        "var_3",
+                        "var_4",
+                        "var_5",
+                        "extra_var",
+                    ],
+                }
+            ],
+        }
+    ]
+
+    inventory = {
+        "appvms": [[vm.name]],
+        "appvms:vars": [["var_1", "foo"]],
+        "all": [
+            [f"{vm.name} var_2", "foo"],
+        ],
+    }
+
+    host_vars = {
+        vm.name: {"var_3": "foo"},
+    }
+
+    group_vars = {
+        "appvms": {"var_4": "foo"},
+        "all": {"var_5": "foo"},
+    }
+
+    result = run_playbook(
+        playbook,
+        inventory=inventory,
+        host_vars=host_vars,
+        group_vars=group_vars,
+        extra_args=["-e", "extra_var=foo"],
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (
+        "Could not match supplied host pattern" not in result.stderr
+    ), result.stderr
+
+
+def test_proxy_yaml_inventory(run_playbook, vm):
+    playbook = [
+        {
+            "hosts": "appvms",
+            "tasks": [
+                {
+                    "fail": {"msg": "undefined var {{ item }}"},
+                    "when": "lookup('vars', item) is undefined",
+                    "loop": [
+                        "host_var",
+                        "group_var",
+                    ],
+                }
+            ],
+        }
+    ]
+
+    inventory = {
+        "appvms": {
+            "hosts": {vm.name: {"host_var": "foo"}},
+            "vars": {"group_var": "foo"},
+        }
+    }
+
+    result = run_playbook(
+        playbook, inventory=inventory, inventory_format="yaml"
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (
+        "Could not match supplied host pattern" not in result.stderr
+    ), result.stderr
+
+
+def test_proxy_with_dict_in_variable(run_playbook, vm):
+    playbook = [
+        {
+            "hosts": "appvms",
+            "tasks": [
+                {
+                    "assert": {
+                        "that": "my_dict['my_item']['my_subitem'] == 'foo'"
+                    },
+                }
+            ],
+        }
+    ]
+
+    inventory = {
+        "appvms": [[vm.name]],
+    }
+
+    group_vars = {"appvms": {"my_dict": {"my_item": {"my_subitem": "foo"}}}}
+
+    result = run_playbook(playbook, inventory=inventory, group_vars=group_vars)
+
+    assert result.returncode == 0, result.stderr
+    assert (
+        "Could not match supplied host pattern" not in result.stderr
+    ), result.stderr


### PR DESCRIPTION
This PR brings the following fixes and improvements to qubes-ansible:

- `qubes_proxy` now builds a merged view of all the target host's variables (extra vars, inventory vars, host vars, group vars...) and put all of those in a host vars file.
- The playbook is exported using AnsibleDumper to prevent encoding issues
- the callback plugin interrupts Ansible execution when detecting qubes connection without proxy
- New tests for the proxy and the callback plugin
- Permissions adjustment on policy files 