### PR TITLE
fix: state of a non-existing vm should be absent

### DIFF
--- a/plugins/modules/qubesos.py
+++ b/plugins/modules/qubesos.py
@@ -324,14 +324,17 @@ class QubesVirt(object):
 
     def __get_state(self, vmname):
         """Determine the current power state of a qube."""
-        vm = self.app.domains[vmname]
-        if vm.is_paused():
-            return "paused"
-        if vm.is_running():
-            return "running"
-        if vm.is_halted():
-            return "shutdown"
-        return None
+        try:
+            vm = self.app.domains[vmname]
+            if vm.is_paused():
+                return "paused"
+            if vm.is_running():
+                return "running"
+            if vm.is_halted():
+                return "shutdown"
+            return None
+        except KeyError:
+            return "absent"
 
     def get_states(self):
         """Get the names and states of all qubes."""

--- a/tests/qubes/test_cli.py
+++ b/tests/qubes/test_cli.py
@@ -407,3 +407,24 @@ def test_ansible_doc_qubesos_module():
     assert (
         "> QUBESOS" in result.stdout
     ), "Documentation should mention the module name"
+
+
+@pytest.mark.parametrize(
+    "ansible_config", ["ansible_linear_strategy", "ansible_proxy_strategy"]
+)
+def test_state_absent_when_vm_does_not_exist(run_playbook):
+    playbook = [
+        {
+            "hosts": "localhost",
+            "tasks": [
+                {
+                    "name": "Ensure VM doesn't exist",
+                    "qubesos": {"state": "absent", "name": "not_existing_vm"},
+                }
+            ],
+        }
+    ]
+    result = run_playbook(playbook)
+    assert result.returncode == 0, result.stderr
+    output = json.loads(result.stdout)
+    assert not output["plays"][0]["tasks"][1]["hosts"]["localhost"]["changed"]


### PR DESCRIPTION
When a user wants to ensure a VM is absent from a given system, they would typically write the following task:

```
- name: Ensure my_vm is absent
  qubes:
    name: my_vm
    state: absent
```

If the VM exists, it is deleted as expected. However if it does not exist, the module raises a `KeyError` exception. This PR fixes the issue by returning the state `absent` when checking the state of a non-existing VM.

Fixes https://github.com/QubesOS/qubes-issues/issues/10628
 