### PR TITLE
legacy: label param was ignored when properties param was empty

### DIFF
--- a/plugins/modules/qubesos.py
+++ b/plugins/modules/qubesos.py
@@ -521,10 +521,10 @@ def core(module):
                 for vol in properties_volumes:
                     volumes[vol["name"]] = {"size": vol["size"]}
 
-            # Label is not a module param for the new module
-            if not properties:
-                properties = {}
-            properties["label"] = label
+        # Label is not a module param for the new module
+        if not properties:
+            properties = {}
+        properties["label"] = label
 
         # Call the module
         try:

--- a/plugins/modules/qubesos.py
+++ b/plugins/modules/qubesos.py
@@ -431,7 +431,7 @@ def core(module):
     guest = module.params.get("name", None)
     command = module.params.get("command", None)
     vmtype = module.params.get("vmtype", None)
-    label = module.params.get("label", "red")
+    label = module.params.get("label", None)
     template = module.params.get("template", None)
     properties = module.params.get("properties", {})
     features = module.params.get("features", {})
@@ -522,9 +522,10 @@ def core(module):
                     volumes[vol["name"]] = {"size": vol["size"]}
 
         # Label is not a module param for the new module
-        if not properties:
-            properties = {}
-        properties["label"] = label
+        if label:
+            if not properties:
+                properties = {}
+            properties["label"] = label
 
         # Call the module
         try:
@@ -663,7 +664,7 @@ def main():
             ),
             wait=dict(type="bool", default=True),
             command=dict(type="str", choices=ALL_COMMANDS),
-            label=dict(type="str", default="red"),
+            label=dict(type="str", default=None),
             vmtype=dict(type="str", default="AppVM"),
             template=dict(type="str", default=None),
             properties=dict(type="dict", default={}),

--- a/tests/qubes/test_legacy_qubesos_module.py
+++ b/tests/qubes/test_legacy_qubesos_module.py
@@ -1319,3 +1319,25 @@ def test_create_vm_which_is_its_self_dispvm(vmname, request, qubes):
 
     assert rc == VIRT_SUCCESS
     assert qubes.domains[vmname].default_dispvm == vmname
+
+
+def test_label_change(vmname, request, qubes):
+    request.node.mark_vm_created(vmname)
+    rc, returned_data = core(
+        Module({"state": "present", "name": vmname, "label": "yellow"})
+    )
+    assert rc == VIRT_SUCCESS
+    assert str(qubes.domains[vmname].label) == "yellow"
+    assert returned_data["changed"]
+    assert returned_data["created"]
+    assert returned_data["diff"]["after"]["properties"]["label"] == "yellow"
+
+    rc, returned_data = core(
+        Module({"state": "present", "name": vmname, "label": "green"})
+    )
+    assert rc == VIRT_SUCCESS
+    assert str(qubes.domains[vmname].label) == "green"
+    assert returned_data["changed"]
+    assert not returned_data["created"]
+    assert returned_data["diff"]["before"]["properties"]["label"] == "yellow"
+    assert returned_data["diff"]["after"]["properties"]["label"] == "green"

--- a/tests/qubes/test_legacy_qubesos_module.py
+++ b/tests/qubes/test_legacy_qubesos_module.py
@@ -1341,3 +1341,23 @@ def test_label_change(vmname, request, qubes):
     assert not returned_data["created"]
     assert returned_data["diff"]["before"]["properties"]["label"] == "yellow"
     assert returned_data["diff"]["after"]["properties"]["label"] == "green"
+
+
+def test_label_should_be_changed_only_when_specified(vmname, request, qubes):
+    request.node.mark_vm_created(vmname)
+
+    rc, returned_data = core(
+        Module({"state": "present", "name": vmname, "label": "yellow"})
+    )
+    assert rc == VIRT_SUCCESS
+    assert str(qubes.domains[vmname].label) == "yellow"
+    assert returned_data["changed"]
+    assert returned_data["diff"]["after"]["properties"]["label"] == "yellow"
+
+    rc, returned_data = core(Module({"state": "present", "name": vmname}))
+    assert rc == VIRT_SUCCESS
+    qubes.domains.refresh_cache(force=True)
+    assert str(qubes.domains[vmname].label) == "yellow"
+    assert not returned_data["changed"]
+    assert "properties" not in returned_data["diff"]["before"]
+    assert "properties" not in returned_data["diff"]["after"]


### PR DESCRIPTION
This PR fixes a bug that was causing `label` parameter ignored in the legacy `qubesos` module when `properties` parameter was not set.

Related issue: https://github.com/QubesOS/qubes-issues/issues/10191

