### PR TITLE
Distinguish between default and explicitly set properties values

### DIFF
--- a/ansible_collections/qubesos/core/plugins/module_utils/qubes_module_qube.py
+++ b/ansible_collections/qubesos/core/plugins/module_utils/qubes_module_qube.py
@@ -303,7 +303,13 @@ class QubeModule:
 
         for property_name, property_val in self.wants.properties.items():
             try:
-                before_val = getattr(self.qube, property_name)
+                if self.qube.property_is_default(property_name):
+                    if property_val == "*default*":
+                        continue
+                    before_val = "*default*"
+                else:
+                    before_val = getattr(self.qube, property_name)
+
                 # Useful for VMs
                 if hasattr(before_val, "name"):
                     before_val = before_val.name

--- a/tests/qubes/test_legacy_qubesos_module.py
+++ b/tests/qubes/test_legacy_qubesos_module.py
@@ -1319,3 +1319,39 @@ def test_create_vm_which_is_its_self_dispvm(vmname, request, qubes):
 
     assert rc == VIRT_SUCCESS
     assert qubes.domains[vmname].default_dispvm == vmname
+
+
+def test_setting_qube_value_to_the_same_value_than_default(vm):
+    assert vm.property_is_default("netvm")
+    netvm = vm.netvm.name
+
+    mod = Module(
+        {
+            "state": "present",
+            "name": vm.name,
+            "properties": {"netvm": netvm},
+        }
+    )
+    rc, returned_data = core(mod)
+    assert rc == VIRT_SUCCESS, returned_data
+    assert returned_data["changed"]
+    assert vm.netvm == netvm
+    assert not vm.property_is_default("netvm")
+
+    # Idempotence
+    rc, returned_data = core(mod)
+    assert rc == VIRT_SUCCESS, returned_data
+    assert not returned_data["changed"]
+
+    mod = Module(
+        {
+            "state": "present",
+            "name": vm.name,
+            "properties": {"netvm": "*default*"},
+        }
+    )
+    rc, returned_data = core(mod)
+    assert rc == VIRT_SUCCESS, returned_data
+    assert returned_data["changed"]
+    assert vm.netvm == netvm
+    assert vm.property_is_default("netvm")

--- a/tests/qubes/test_module_qube.py
+++ b/tests/qubes/test_module_qube.py
@@ -433,7 +433,7 @@ def test_properties_reset_to_default_netvm(qubes, vm, netvm):
 
     assert (
         fake_module.returned_data["diff"]["before"]["properties"]["netvm"]
-        == default_netvm.name
+        == "*default*"
     )
     assert (
         fake_module.returned_data["diff"]["after"]["properties"]["netvm"]
@@ -485,7 +485,7 @@ def test_properties_reset_to_default_mac(qubes, vm, request):
 
     assert (
         fake_module.returned_data["diff"]["before"]["properties"]["mac"]
-        == default_mac
+        == "*default*"
     )
     assert (
         fake_module.returned_data["diff"]["after"]["properties"]["mac"] == mac
@@ -1109,7 +1109,6 @@ def test_change_properties_should_occur_only_when_necessary(
         "qrexec_timeout": 180,
         "shutdown_timeout": 180,
         "template_for_dispvms": True,
-        "updateable": False,
         "vcpus": 3,
     }
 
@@ -1204,3 +1203,52 @@ def test_create_vm_which_is_its_self_dispvm(vmname, request, qubes):
     )
     QubeModule(fake_module).run()
     assert qubes.domains[vmname].default_dispvm == vmname
+
+
+def test_setting_qube_value_to_the_same_value_than_default(vm):
+    assert vm.property_is_default("autostart")
+    assert vm.autostart == False
+
+    fake_module = Module(
+        {
+            "state": "present",
+            "name": vm.name,
+            "properties": {"autostart": False},
+        }
+    )
+    QubeModule(fake_module).run()
+    assert fake_module.returned_data["changed"]
+    assert (
+        fake_module.returned_data["diff"]["before"]["properties"]["autostart"]
+        == "*default*"
+    )
+    assert (
+        fake_module.returned_data["diff"]["after"]["properties"]["autostart"]
+        == False
+    )
+    assert vm.autostart == False
+    assert not vm.property_is_default("autostart")
+
+    # Idempotence
+    QubeModule(fake_module).run()
+    assert not fake_module.returned_data["changed"]
+
+    fake_module = Module(
+        {
+            "state": "present",
+            "name": vm.name,
+            "properties": {"autostart": "*default*"},
+        }
+    )
+    QubeModule(fake_module).run()
+    assert fake_module.returned_data["changed"]
+    assert (
+        fake_module.returned_data["diff"]["before"]["properties"]["autostart"]
+        == False
+    )
+    assert (
+        fake_module.returned_data["diff"]["after"]["properties"]["autostart"]
+        == "*default*"
+    )
+    assert vm.autostart == False
+    assert vm.property_is_default("autostart")


### PR DESCRIPTION
This PR introduces a couple of changes to the `qubesos.core.qube` module. When setting a property to the same value as its default, the module previously did nothing, treating the default value and the explicitly set value as identical.

Now, every default value for a qube property is considered as `*default*`. This will trigger an update when a user wants to set an explicit value to a qube.

 ```
# qvm-prefs toto | grep autostart
autostart             D  False
```

Setting autostart to false:
```
- hosts: localhost
  gather_facts: false
  tasks:
    - qubesos.core.qube:
        name: toto
        state: present
        properties:
          autostart: false
```

```
# ansible-playbook -vvv test.yml 
TASK [qubesos.core.qube] *********************************************************************************************************************************************************************
changed: [localhost] => {
    "changed": true,
    "created": false,
    "deleted": false,
    "diff": {
        "after": {
            "properties": {
                "autostart": false
            }
        },
        "before": {
            "properties": {
                "autostart": "*default*"
            }
        }
    },
    "invocation": {
        "module_args": {
            "clone_src": null,
            "devices": null,
            "features": null,
            "klass": "AppVM",
            "name": "toto",
            "notes": null,
            "properties": {
                "autostart": false
            },
            "services": null,
            "shutdown_if_required": false,
            "state": "present",
            "tags": [],
            "template": null,
            "volumes": null
        }
    }
}   
```

Returned data detected changes (`"changed": true`) and `diff:` shows `autostart` has changed from `*default*` to `false`.  

```
# qvm-prefs toto | grep autostart
autostart             -  False
```

fixes https://github.com/QubesOS/qubes-issues/issues/10435