### PR TITLE
Remove default value for klass (vmtype) parameter

### DIFF
--- a/ansible_collections/qubesos/core/plugins/module_utils/qubes_module_qube.py
+++ b/ansible_collections/qubesos/core/plugins/module_utils/qubes_module_qube.py
@@ -631,7 +631,7 @@ def main():
             shutdown_if_required=dict(type="bool", default=False),
             tags=dict(type="list", default=[]),
             template=dict(type="str", default=None),
-            klass=dict(type="str", default="AppVM", aliases=["vmtype"]),
+            klass=dict(type="str", default=None, aliases=["vmtype"]),
             volumes=dict(type="dict", default=None),
         ),
     )

--- a/ansible_collections/qubesos/core/plugins/module_utils/qubes_module_qube.py
+++ b/ansible_collections/qubesos/core/plugins/module_utils/qubes_module_qube.py
@@ -109,9 +109,6 @@ class QubeModule:
             klass=module.params.get("klass"),
         )
 
-        if self.wants.properties is None:
-            self.wants.properties = {}
-
         # Sync template var with template key in properties var
         # No template property for TemplateVMs and StandaloneVMs
         if self.wants.klass not in ("TemplateVM", "StandaloneVM"):

--- a/ansible_collections/qubesos/core/plugins/module_utils/qubes_module_qube.py
+++ b/ansible_collections/qubesos/core/plugins/module_utils/qubes_module_qube.py
@@ -516,7 +516,7 @@ class QubeModule:
             if property in ["default_dispvm", "management_dispvm"]:
                 if not vm.klass == "AppVM" or not vm.template_for_dispvms:
                     self.module.fail_json(
-                        msg=f"Cannot set value '{value}' to property '{property}: the qube is not a template for dispvm",
+                        msg=f"Cannot set value '{value}' to property '{property}': the qube is not a template for dispvm",
                     )
 
     def validate_services(self):
@@ -530,7 +530,7 @@ class QubeModule:
             self.wants.features[f"service.{service}"] = "1"
 
     def validate_volumes(self):
-        """Validates 'volumes' module parameters (variable f"""
+        """Validates 'volumes' module parameter"""
         try:
             for volume_name, volume_config in self.wants.volumes.items():
                 if volume_name not in ["private", "root"]:

--- a/plugins/modules/qubesos.py
+++ b/plugins/modules/qubesos.py
@@ -446,20 +446,6 @@ def core(module):
             f"usage of 'wait' parameter in qubesos module is no more supported."
         )
 
-    if state == "present" and guest:
-        try:
-            vm = v.get_vm(guest)
-            vmtype = vm.klass
-        except KeyError:
-            # Set default vmtype to AppVM if vmtype is not provided
-            vmtype = vmtype or "AppVM"
-
-    # Validation
-    try:
-        _validate_properties(guest, v, properties, vmtype)
-    except ValidationFailure as e:
-        return VIRT_FAILED, e.reasons
-
     # gather device facts
     # here, we just need to call the relevant module and retrieve the facts
     if module.params.get("gather_device_facts", False):
@@ -474,10 +460,23 @@ def core(module):
     if state == "present" and guest:
         # Process conversion from legacy module format to new module format
 
+        try:
+            vm = v.get_vm(guest)
+            target_vmtype = vm.klass
+        except KeyError:
+            # Set default vmtype to AppVM if vmtype is not provided
+            target_vmtype = vmtype or "AppVM"
+
+        # Validation
+        try:
+            _validate_properties(guest, v, properties, target_vmtype)
+        except ValidationFailure as e:
+            return VIRT_FAILED, e.reasons
+
         # template / clone_src
         # Legacy module was cloning VMs in those cases
         if (
-            vmtype == "AppVM"
+            vmtype in ["AppVM", None]
             and template
             and v.get_vm(template)._klass == "AppVM"
         ):
@@ -665,7 +664,7 @@ def main():
             wait=dict(type="bool", default=True),
             command=dict(type="str", choices=ALL_COMMANDS),
             label=dict(type="str", default=None),
-            vmtype=dict(type="str", default="AppVM"),
+            vmtype=dict(type="str", default=None),
             template=dict(type="str", default=None),
             properties=dict(type="dict", default={}),
             features=dict(type="dict", default={}),

--- a/tests/qubes/ansible_test_utils.py
+++ b/tests/qubes/ansible_test_utils.py
@@ -1,0 +1,84 @@
+import json
+from unittest.mock import patch
+
+from ansible.module_utils import basic
+from ansible.module_utils.common.text.converters import to_bytes
+
+from plugins.modules.qubesos import (
+    main as qubesos_legacy_main,
+)
+
+from ansible_collections.qubesos.core.plugins.module_utils.qubes_module_qube import (
+    main as qubesos_core_qube_main,
+)
+
+from ansible_collections.qubesos.core.plugins.module_utils.qubes_module_host_devices_facts import (
+    main as qubesos_core_host_devices_facts_main,
+)
+
+from ansible_collections.qubesos.core.plugins.module_utils.qubes_module_command import (
+    main as qubesos_core_command_main,
+)
+
+
+class AnsibleExitJson(Exception):
+    pass
+
+
+class AnsibleFailJson(Exception):
+    pass
+
+
+def exit_json(*args, **kwargs):
+    if "changed" not in kwargs:
+        kwargs["changed"] = False
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    kwargs["failed"] = True
+    raise AnsibleFailJson(kwargs)
+
+
+def set_module_args(args):
+    basic._ANSIBLE_ARGS = to_bytes(json.dumps({"ANSIBLE_MODULE_ARGS": args}))
+
+
+def run_patched_module(args, module):
+    """Run the specified module. Returns result dict on success, raises AnsibleFailJson on failure."""
+    set_module_args(args)
+    with patch.multiple(
+        basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json
+    ):
+        try:
+            module()
+        except AnsibleExitJson as e:
+            return e.args[0]
+    raise AssertionError("Module did not call exit_json or fail_json")
+
+
+def run_module_qubesos_core_qube_main(args):
+    return run_patched_module(args, qubesos_core_qube_main)
+
+
+def run_module_qubesos_core_host_devices_facts(args):
+    return run_patched_module(args, qubesos_core_host_devices_facts_main)
+
+
+def run_module_qubesos_core_command(args):
+    return run_patched_module(args, qubesos_core_command_main)
+
+
+def run_module_qubesos_legacy(args):
+    """Run the qube module. Returns result dict on success, raises AnsibleFailJson on failure."""
+    set_module_args(args)
+    with patch.multiple(
+        basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json
+    ):
+        try:
+            qubesos_legacy_main()
+        except AnsibleExitJson as e:
+            return 0, e.args[0]
+        except AnsibleFailJson as e:
+            return e.args[0]["rc"], e.args[0]["msg"]
+    raise AssertionError("Module did not call exit_json or fail_json")

--- a/tests/qubes/conftest.py
+++ b/tests/qubes/conftest.py
@@ -7,29 +7,12 @@ from qubesadmin.utils import vm_dependencies
 
 sys.path.append("/usr/share/ansible/collections")
 
-from ansible_collections.qubesos.core.plugins.module_utils.qubes_module_qube import (
-    QubeModule,
+from tests.qubes.ansible_test_utils import (
+    AnsibleFailJson,
+    run_module_qubesos_core_qube_main as run_module,
 )
 
 DEBIAN_TEMPLATE = "debian-12-minimal"
-
-
-class ModuleExitWithError(Exception):
-    pass
-
-
-# Helper to run the module core function
-class Module:
-    def __init__(self, params):
-        self.params = params
-        self.returned_data = None
-
-    def fail_json(self, **kwargs):
-        self.returned_data = kwargs
-        raise ModuleExitWithError(kwargs)
-
-    def exit_json(self, **kwargs):
-        self.returned_data = kwargs
 
 
 @pytest.fixture(scope="function")
@@ -51,7 +34,7 @@ def vmname():
 def vm(qubes, request):
     """Generate a VM with default configurations"""
     vmname = f"test-vm-{uuid.uuid4().hex[:8]}"
-    QubeModule(Module({"state": "present", "name": vmname})).run()
+    run_module({"state": "present", "name": vmname})
     request.node.mark_vm_created(vmname)
 
     qubes.domains.refresh_cache(force=True)
@@ -61,11 +44,9 @@ def vm(qubes, request):
 @pytest.fixture(scope="function")
 def minimalvm(qubes, request):
     vmname = f"test-minimalvm-{uuid.uuid4().hex[:8]}"
-    QubeModule(
-        Module(
-            {"state": "present", "name": vmname, "template": DEBIAN_TEMPLATE}
-        )
-    ).run()
+    run_module(
+        {"state": "present", "name": vmname, "template": DEBIAN_TEMPLATE}
+    )
     request.node.mark_vm_created(vmname)
 
     qubes.domains.refresh_cache(force=True)
@@ -75,10 +56,13 @@ def minimalvm(qubes, request):
 @pytest.fixture(scope="function")
 def netvm(qubes, request):
     vmname = f"test-netvm-{uuid.uuid4().hex[:8]}"
-    props = {"provides_network": True}
-    QubeModule(
-        Module({"state": "present", "name": vmname, "properties": props})
-    ).run()
+    run_module(
+        {
+            "state": "present",
+            "name": vmname,
+            "properties": {"provides_network": True},
+        }
+    )
     request.node.mark_vm_created(vmname)
 
     qubes.domains.refresh_cache(force=True)
@@ -88,7 +72,7 @@ def netvm(qubes, request):
 @pytest.fixture(scope="function")
 def audiovm(qubes, request):
     vmname = f"test-audiovm-{uuid.uuid4().hex[:8]}"
-    QubeModule(Module({"state": "present", "name": vmname})).run()
+    run_module({"state": "present", "name": vmname})
     request.node.mark_vm_created(vmname)
 
     qubes.domains.refresh_cache(force=True)
@@ -98,7 +82,7 @@ def audiovm(qubes, request):
 @pytest.fixture(scope="function")
 def guivm(qubes, request):
     vmname = f"test-guivm-{uuid.uuid4().hex[:8]}"
-    QubeModule(Module({"state": "present", "name": vmname})).run()
+    run_module({"state": "present", "name": vmname})
     request.node.mark_vm_created(vmname)
 
     qubes.domains.refresh_cache(force=True)
@@ -108,15 +92,13 @@ def guivm(qubes, request):
 @pytest.fixture(scope="function")
 def managementdvm(qubes, request):
     vmname = f"test-mdvm-{uuid.uuid4().hex[:8]}"
-    QubeModule(
-        Module(
-            {
-                "state": "present",
-                "name": vmname,
-                "properties": {"template_for_dispvms": True},
-            }
-        )
-    ).run()
+    run_module(
+        {
+            "state": "present",
+            "name": vmname,
+            "properties": {"template_for_dispvms": True},
+        }
+    )
     request.node.mark_vm_created(vmname)
 
     qubes.domains.refresh_cache(force=True)
@@ -163,7 +145,10 @@ def cleanup_vm(qubes, request):
                 setattr(holder, prop_name, None)
 
         # now remove the VM itself
-        QubeModule(Module({"state": "absent", "name": name})).run()
+        try:
+            run_module({"state": "absent", "name": name})
+        except AnsibleFailJson:
+            pass
 
 
 @pytest.fixture

--- a/tests/qubes/test_gather_pci_facts.py
+++ b/tests/qubes/test_gather_pci_facts.py
@@ -1,19 +1,14 @@
-import os
-import pytest
-import time
-
-from ansible_collections.qubesos.core.plugins.module_utils.qubes_module_host_devices_facts import (
-    core,
+from tests.qubes.ansible_test_utils import (
+    run_module_qubesos_core_host_devices_facts as run_module,
 )
-from tests.qubes.conftest import qubes, vmname, Module, ModuleExitWithError
+from tests.qubes.conftest import qubes
 
 
 def test_devices_pci_facts_match_actual(qubes):
     # Gather PCI facts from the module
-    fake_module = Module({"gather_device_facts": True})
-    core(fake_module)
+    res = run_module({})
 
-    facts = fake_module.returned_data["ansible_facts"]
+    facts = res["ansible_facts"]
     assert "pci_net" in facts
     assert "pci_usb" in facts
     assert "pci_audio" in facts

--- a/tests/qubes/test_legacy_qubesos_module.py
+++ b/tests/qubes/test_legacy_qubesos_module.py
@@ -2,8 +2,11 @@ import pytest
 import os
 import time
 
-from plugins.modules.qubesos import core, VIRT_SUCCESS, VIRT_FAILED
-from tests.qubes.conftest import qubes, vmname, Module
+from plugins.modules.qubesos import VIRT_SUCCESS, VIRT_FAILED
+from tests.qubes.ansible_test_utils import (
+    run_module_qubesos_legacy as run_module,
+)
+from tests.qubes.conftest import qubes, vmname
 
 
 def test_lifecycle_full_create_start_shutdown_remove(qubes, vmname, request):
@@ -11,26 +14,24 @@ def test_lifecycle_full_create_start_shutdown_remove(qubes, vmname, request):
     request.node.mark_vm_created(vmname)
 
     # Create
-    rc, _ = core(
-        Module({"command": "create", "name": vmname, "vmtype": "AppVM"})
-    )
+    rc, _ = run_module({"command": "create", "name": vmname, "vmtype": "AppVM"})
     assert rc == VIRT_SUCCESS
     assert vmname in qubes.domains
 
     # Start
-    rc, _ = core(Module({"command": "start", "name": vmname}))
+    rc, _ = run_module({"command": "start", "name": vmname})
     assert rc == VIRT_SUCCESS
     vm = qubes.domains[vmname]
     assert vm.is_running()
 
     # Shutdown
-    rc, _ = core(Module({"command": "shutdown", "name": vmname}))
+    rc, _ = run_module({"command": "shutdown", "name": vmname})
     assert rc == VIRT_SUCCESS
     time.sleep(5)
     assert vm.is_halted()
 
     # Remove
-    rc, _ = core(Module({"command": "remove", "name": vmname}))
+    rc, _ = run_module({"command": "remove", "name": vmname})
     assert rc == VIRT_SUCCESS
     qubes.domains.refresh_cache(force=True)
     assert vmname not in qubes.domains
@@ -40,14 +41,12 @@ def test_lifecycle_create_and_absent(qubes, vmname, request):
     request.node.mark_vm_created(vmname)
 
     # Create
-    rc, _ = core(
-        Module({"command": "create", "name": vmname, "vmtype": "AppVM"})
-    )
+    rc, _ = run_module({"command": "create", "name": vmname, "vmtype": "AppVM"})
     assert rc == VIRT_SUCCESS
     assert vmname in qubes.domains
 
     # Absent
-    rc, _ = core(Module({"state": "absent", "name": vmname}))
+    rc, _ = run_module({"state": "absent", "name": vmname})
     assert rc == VIRT_SUCCESS
     qubes.domains.refresh_cache(force=True)
     assert vmname not in qubes.domains
@@ -55,39 +54,39 @@ def test_lifecycle_create_and_absent(qubes, vmname, request):
 
 def test_lifecycle_pause_and_resume(qubes, vmname, request):
     request.node.mark_vm_created(vmname)
-    core(Module({"command": "create", "name": vmname, "vmtype": "AppVM"}))
-    core(Module({"command": "start", "name": vmname}))
+    run_module({"command": "create", "name": vmname, "vmtype": "AppVM"})
+    run_module({"command": "start", "name": vmname})
     time.sleep(1)
 
-    rc, _ = core(Module({"command": "pause", "name": vmname}))
+    rc, _ = run_module({"command": "pause", "name": vmname})
     assert rc == VIRT_SUCCESS
     assert qubes.domains[vmname].is_paused()
 
-    rc, _ = core(Module({"command": "unpause", "name": vmname}))
+    rc, _ = run_module({"command": "unpause", "name": vmname})
     assert rc == VIRT_SUCCESS
     assert qubes.domains[vmname].is_running()
 
     # Clean up
-    core(Module({"command": "destroy", "name": vmname}))
-    core(Module({"state": "absent", "name": vmname}))
+    run_module({"command": "destroy", "name": vmname})
+    run_module({"state": "absent", "name": vmname})
 
 
 def test_lifecycle_status_reporting(qubes, vmname, request):
     request.node.mark_vm_created(vmname)
-    core(Module({"command": "create", "name": vmname, "vmtype": "AppVM"}))
-    rc, state = core(Module({"command": "status", "name": vmname}))
+    run_module({"command": "create", "name": vmname, "vmtype": "AppVM"})
+    rc, state = run_module({"command": "status", "name": vmname})
     assert rc == VIRT_SUCCESS
     assert state["status"] == "shutdown"
 
-    core(Module({"command": "start", "name": vmname}))
-    rc, state = core(Module({"command": "status", "name": vmname}))
+    run_module({"command": "start", "name": vmname})
+    rc, state = run_module({"command": "status", "name": vmname})
     assert state["status"] == "running"
 
-    core(Module({"command": "destroy", "name": vmname}))
-    rc, state = core(Module({"command": "status", "name": vmname}))
+    run_module({"command": "destroy", "name": vmname})
+    rc, state = run_module({"command": "status", "name": vmname})
     assert state["status"] == "shutdown"
 
-    core(Module({"state": "absent", "name": vmname}))
+    run_module({"state": "absent", "name": vmname})
 
 
 def test_create_clone_vmtype_combinations(qubes, vmname, request):
@@ -97,74 +96,70 @@ def test_create_clone_vmtype_combinations(qubes, vmname, request):
     # request.node.mark_vm_created(f"{vmname}-clone-standalonevm")
 
     # Test creating / cloning from AppVM
-    core(Module({"command": "create", "name": vmname, "vmtype": "AppVM"}))
-    rc, _ = core(
-        Module(
-            {
-                "command": "create",
-                "name": f"{vmname}-clone-appvm",
-                "template": vmname,
-                "vmtype": "AppVM",
-            }
-        )
+    run_module({"command": "create", "name": vmname, "vmtype": "AppVM"})
+    rc, _ = run_module(
+        {
+            "command": "create",
+            "name": f"{vmname}-clone-appvm",
+            "template": vmname,
+            "vmtype": "AppVM",
+        }
     )
 
     assert rc == VIRT_SUCCESS
     assert f"{vmname}-clone-appvm" in qubes.domains
 
-    # rc, _ = core(Module({"command": "create", "name": f"{vmname}-clone-templatevm", "template": vmname, "vmtype": "TemplateVM"}))
+    # rc, _ = run_module({"command": "create", "name": f"{vmname}-clone-templatevm", "template": vmname, "vmtype": "TemplateVM"})
     # assert rc == VIRT_SUCCESS
     # assert f"{vmname}-clone-templatevm" in qubes.domains
 
-    # rc, _ = core(Module({"command": "create", "name": f"{vmname}-clone-standalonevm", "template": vmname, "vmtype": "StandaloneVM"}))
+    # rc, _ = run_module({"command": "create", "name": f"{vmname}-clone-standalonevm", "template": vmname, "vmtype": "StandaloneVM"})
     # assert rc == VIRT_SUCCESS
     # assert f"{vmname}-clone-standalonevm" in qubes.domains
 
     # Test creating / cloning from TemplateVM
-    core(Module({"command": "create", "name": vmname, "vmtype": "TemplateVM"}))
-    rc, _ = core(
-        Module(
-            {
-                "command": "create",
-                "name": f"{vmname}-clone-appvm",
-                "template": vmname,
-                "vmtype": "AppVM",
-            }
-        )
+    run_module({"command": "create", "name": vmname, "vmtype": "TemplateVM"})
+    rc, _ = run_module(
+        {
+            "command": "create",
+            "name": f"{vmname}-clone-appvm",
+            "template": vmname,
+            "vmtype": "AppVM",
+        }
     )
 
     assert rc == VIRT_SUCCESS
     assert f"{vmname}-clone-appvm" in qubes.domains
     #
-    # rc, _ = core(Module({"command": "create", "name": f"{vmname}-clone-templatevm", "template": vmname, "vmtype": "TemplateVM"}))
+    # rc, _ = run_module({"command": "create", "name": f"{vmname}-clone-templatevm", "template": vmname, "vmtype": "TemplateVM"})
     #
     # assert rc == VIRT_SUCCESS
     # assert f"{vmname}-clone-templatevm" in qubes.domains
     #
-    # rc, _ = core(Module({"command": "create", "name": f"{vmname}-clone-standalonevm", "template": vmname, "vmtype": "StandaloneVM"}))
+    # rc, _ = run_module({"command": "create", "name": f"{vmname}-clone-standalonevm", "template": vmname, "vmtype": "StandaloneVM"})
     #
     # assert rc == VIRT_SUCCESS
     # assert f"{vmname}-clone-standalonevm" in qubes.domains
     #
     # # Test creating / cloning from StandaloneVM
-    # core(Module({"command": "create", "name": vmname, "vmtype": "StandaloneVM"}))
-    # rc, _ = core(Module({"command": "create", "name": f"{vmname}-clone-appvm", "template": vmname, "vmtype": "AppVM"}))
+    # run_module({"command": "create", "name": vmname, "vmtype": "StandaloneVM"})
+    # rc, _ = run_module({"command": "create", "name": f"{vmname}-clone-appvm", "template": vmname, "vmtype": "AppVM"})
     # assert rc == VIRT_SUCCESS
     # assert f"{vmname}-clone-appvm" in qubes.domains
     #
-    # rc, _ = core(Module({"command": "create", "name": f"{vmname}-clone-templatevm", "template": vmname, "vmtype": "TemplateVM"}))
+    # rc, _ = run_module({"command": "create", "name": f"{vmname}-clone-templatevm", "template": vmname, "vmtype": "TemplateVM"})
     # assert rc == VIRT_SUCCESS
     # assert f"{vmname}-clone-templatevm" in qubes.domains
     #
-    # rc, _ = core(Module({"command": "create", "name": f"{vmname}-clone-standalonevm", "template": vmname, "vmtype": "StandaloneVM"}))
+    # rc, _ = run_module({"command": "create", "name": f"{vmname}-clone-standalonevm", "template": vmname, "vmtype": "StandaloneVM"})
     # assert rc == VIRT_SUCCESS
     # assert f"{vmname}-clone-standalonevm" in qubes.domains
     #
     # Cleanup
-    core(Module({"state": "absent", "name": f"{vmname}-clone-appvm"}))
-    # core(Module({"state": "absent", "name": f"{vmname}-clone-templatevm"}))
-    # core(Module({"state": "absent", "name": f"{vmname}-clone-standalonevm"}))
-    core(Module({"state": "absent", "name": vmname}))
+    run_module({"state": "absent", "name": f"{vmname}-clone-appvm"})
+    # run_module({"state": "absent", "name": f"{vmname}-clone-templatevm"})
+    # run_module({"state": "absent", "name": f"{vmname}-clone-standalonevm"})
+    run_module({"state": "absent", "name": vmname})
 
 
 def test_create_clone_vmtype_combinations_2(qubes, vmname, request):
@@ -181,21 +176,19 @@ def test_create_clone_vmtype_combinations_2(qubes, vmname, request):
     request.node.mark_vm_created(standalone_clone_name_2)
 
     # 1- create an AppVM
-    rc, returned_data = core(
-        Module({"state": "present", "name": vmname, "vmtype": "AppVM"})
+    rc, returned_data = run_module(
+        {"state": "present", "name": vmname, "vmtype": "AppVM"}
     )
     assert returned_data["created"]
 
     # 2- Clone this AppVM
-    rc, returned_data = core(
-        Module(
-            {
-                "state": "present",
-                "name": appvm_clone_name,
-                "vmtype": "AppVM",
-                "template": vmname,
-            }
-        )
+    rc, returned_data = run_module(
+        {
+            "state": "present",
+            "name": appvm_clone_name,
+            "vmtype": "AppVM",
+            "template": vmname,
+        }
     )
     qubes.domains.refresh_cache(force=True)
     assert returned_data["created"]
@@ -203,15 +196,13 @@ def test_create_clone_vmtype_combinations_2(qubes, vmname, request):
     assert qubes.domains[appvm_clone_name].klass == "AppVM"
 
     # 3- Clone a template
-    rc, returned_data = core(
-        Module(
-            {
-                "state": "present",
-                "name": template_clone_name,
-                "vmtype": "TemplateVM",
-                "template": qubes.default_template,
-            }
-        )
+    rc, returned_data = run_module(
+        {
+            "state": "present",
+            "name": template_clone_name,
+            "vmtype": "TemplateVM",
+            "template": qubes.default_template.name,
+        }
     )
     qubes.domains.refresh_cache(force=True)
     assert returned_data["created"]
@@ -219,15 +210,13 @@ def test_create_clone_vmtype_combinations_2(qubes, vmname, request):
     assert qubes.domains[template_clone_name].klass == "TemplateVM"
 
     # 4- Create a Standalone VM from that template
-    core(
-        Module(
-            {
-                "state": "present",
-                "name": standalone_clone_name_1,
-                "vmtype": "StandaloneVM",
-                "template": template_clone_name,
-            }
-        )
+    run_module(
+        {
+            "state": "present",
+            "name": standalone_clone_name_1,
+            "vmtype": "StandaloneVM",
+            "template": template_clone_name,
+        }
     )
     qubes.domains.refresh_cache(force=True)
     assert returned_data["created"]
@@ -235,15 +224,13 @@ def test_create_clone_vmtype_combinations_2(qubes, vmname, request):
     assert qubes.domains[standalone_clone_name_1].klass == "StandaloneVM"
 
     # 5- Clone this StandaloneVM
-    core(
-        Module(
-            {
-                "state": "present",
-                "name": standalone_clone_name_2,
-                "vmtype": "StandaloneVM",
-                "template": standalone_clone_name_1,
-            }
-        )
+    run_module(
+        {
+            "state": "present",
+            "name": standalone_clone_name_2,
+            "vmtype": "StandaloneVM",
+            "template": standalone_clone_name_1,
+        }
     )
     qubes.domains.refresh_cache(force=True)
     assert returned_data["created"]
@@ -255,21 +242,19 @@ def test_volumes_list_for_standalonevm(qubes, vmname, request):
     request.node.mark_vm_created(vmname)
 
     # Create StandaloneVM
-    rc, res = core(
-        Module(
-            {
-                "state": "present",
-                "name": vmname,
-                "vmtype": "StandaloneVM",
-                "template": "debian-13-xfce",
-                "properties": {
-                    "volumes": [
-                        {"name": "root", "size": 32212254720},
-                        {"name": "private", "size": 10737418240},
-                    ]
-                },
-            }
-        )
+    rc, res = run_module(
+        {
+            "state": "present",
+            "name": vmname,
+            "vmtype": "StandaloneVM",
+            "template": "debian-13-xfce",
+            "properties": {
+                "volumes": [
+                    {"name": "root", "size": 32212254720},
+                    {"name": "private", "size": 10737418240},
+                ]
+            },
+        }
     )
     assert rc == VIRT_SUCCESS
     vm = qubes.domains[vmname]
@@ -278,16 +263,12 @@ def test_volumes_list_for_standalonevm(qubes, vmname, request):
     assert vm.volumes["private"].size == 10737418240
 
     # Resize root
-    rc2, res2 = core(
-        Module(
-            {
-                "state": "present",
-                "name": vmname,
-                "properties": {
-                    "volumes": [{"name": "root", "size": 42949672960}]
-                },
-            }
-        )
+    rc2, res2 = run_module(
+        {
+            "state": "present",
+            "name": vmname,
+            "properties": {"volumes": [{"name": "root", "size": 42949672960}]},
+        }
     )
     assert rc2 == VIRT_SUCCESS
     assert "volume:root" in res2.get("Properties updated", [])
@@ -299,15 +280,13 @@ def test_inventory_generation_and_grouping(tmp_path, qubes):
     os.chdir(tmp_path)
 
     # Create a standalone VM (by default we don't have any)
-    core(
-        Module(
-            {
-                "command": "create",
-                "name": "teststandalone",
-                "vmtype": "StandaloneVM",
-                "template": "debian-13-xfce",
-            }
-        )
+    run_module(
+        {
+            "command": "create",
+            "name": "teststandalone",
+            "vmtype": "StandaloneVM",
+            "template": "debian-13-xfce",
+        }
     )
 
     # Collect expected VMs by class
@@ -318,7 +297,7 @@ def test_inventory_generation_and_grouping(tmp_path, qubes):
         expected.setdefault(vm.klass, []).append(vm.name)
 
     # Run createinventory
-    rc, res = core(Module({"command": "createinventory"}))
+    rc, res = run_module({"command": "createinventory"})
     assert rc == VIRT_SUCCESS
     assert res["status"] == "successful"
 
@@ -360,7 +339,7 @@ def test_properties_and_features_set_and_tag_vm(qubes, vmname, request):
         "tags": tags,
         "notes": "For your eyes only",
     }
-    rc, res = core(Module(params))
+    rc, res = run_module(params)
     assert rc == VIRT_SUCCESS
     props_values = res["Properties updated"]
     assert "autostart" in props_values
@@ -381,7 +360,7 @@ def test_properties_and_features_set_and_tag_vm(qubes, vmname, request):
         "name": vmname,
         "tags": tags,
     }
-    rc, res = core(Module(params))
+    rc, res = run_module(params)
     assert rc == VIRT_SUCCESS
     assert "Tags updated" in res
     for t in tags:
@@ -396,7 +375,7 @@ def test_features_vm(qubes, vmname, request):
         "name": vmname,
         "features": feats,
     }
-    rc, res = core(Module(params))
+    rc, res = run_module(params)
     assert rc == VIRT_SUCCESS
     feats_values = res["Features updated"]
     assert "life" in feats_values
@@ -407,10 +386,8 @@ def test_features_vm(qubes, vmname, request):
 
 def test_properties_invalid_key(qubes):
     # Unknown property should fail
-    rc, res = core(
-        Module(
-            {"state": "present", "name": "dom0", "properties": {"titi": "toto"}}
-        )
+    rc, res = run_module(
+        {"state": "present", "name": "dom0", "properties": {"titi": "toto"}}
     )
     assert rc == VIRT_FAILED
     assert "Invalid property" in res
@@ -418,14 +395,12 @@ def test_properties_invalid_key(qubes):
 
 def test_properties_invalid_type(qubes, vmname, request):
     # Wrong type for memory
-    rc, res = core(
-        Module(
-            {
-                "state": "present",
-                "name": vmname,
-                "properties": {"memory": "toto"},
-            }
-        )
+    rc, res = run_module(
+        {
+            "state": "present",
+            "name": vmname,
+            "properties": {"memory": "toto"},
+        }
     )
     assert rc == VIRT_FAILED
     assert "Invalid property value type" in res
@@ -433,14 +408,12 @@ def test_properties_invalid_type(qubes, vmname, request):
 
 def test_properties_missing_netvm(qubes, vmname, request):
     # netvm does not exist
-    rc, res = core(
-        Module(
-            {
-                "state": "present",
-                "name": vmname,
-                "properties": {"netvm": "toto"},
-            }
-        )
+    rc, res = run_module(
+        {
+            "state": "present",
+            "name": vmname,
+            "properties": {"netvm": "toto"},
+        }
     )
     assert rc == VIRT_FAILED
     assert "Missing netvm" in res
@@ -453,27 +426,23 @@ def test_properties_reset_to_default_netvm(qubes, vm, netvm, request):
     default_netvm = vm.netvm
 
     # Change to non-default netvm
-    change_netvm_rc, change_netvm_res = core(
-        Module(
-            {
-                "state": "present",
-                "name": vm.name,
-                "properties": {"netvm": netvm.name},
-            }
-        )
+    change_netvm_rc, change_netvm_res = run_module(
+        {
+            "state": "present",
+            "name": vm.name,
+            "properties": {"netvm": netvm.name},
+        }
     )
     assert "netvm" in change_netvm_res["Properties updated"]
     assert change_netvm_rc == VIRT_SUCCESS
 
     # Ability to reset back to default netvm, whichever it is
-    reset_netvm_rc, reset_netvm_res = core(
-        Module(
-            {
-                "state": "present",
-                "name": vm.name,
-                "properties": {"netvm": "*default*"},
-            }
-        )
+    reset_netvm_rc, reset_netvm_res = run_module(
+        {
+            "state": "present",
+            "name": vm.name,
+            "properties": {"netvm": "*default*"},
+        }
     )
     assert "netvm" in reset_netvm_res["Properties updated"]
     assert default_netvm != netvm
@@ -493,27 +462,23 @@ def test_properties_reset_to_default_mac(qubes, vm, request):
     mac = "11:22:33:44:55:66"
 
     # Change to non-default mac
-    change_rc, change_res = core(
-        Module(
-            {
-                "state": "present",
-                "name": vm.name,
-                "properties": {"mac": mac},
-            }
-        )
+    change_rc, change_res = run_module(
+        {
+            "state": "present",
+            "name": vm.name,
+            "properties": {"mac": mac},
+        }
     )
     assert "mac" in change_res["Properties updated"]
     assert change_rc == VIRT_SUCCESS
 
     # Ability to reset back to default mac, whatever it is
-    reset_rc, reset_res = core(
-        Module(
-            {
-                "state": "present",
-                "name": vm.name,
-                "properties": {"mac": "*default*"},
-            }
-        )
+    reset_rc, reset_res = run_module(
+        {
+            "state": "present",
+            "name": vm.name,
+            "properties": {"mac": "*default*"},
+        }
     )
     assert "mac" in reset_res["Properties updated"]
     assert default_mac != mac
@@ -525,14 +490,12 @@ def test_properties_reset_to_default_mac(qubes, vm, request):
 
 def test_properties_missing_default_dispvm(qubes):
     # default_dispvm does not exist
-    rc, res = core(
-        Module(
-            {
-                "state": "present",
-                "name": "dom0",
-                "properties": {"default_dispvm": "toto"},
-            }
-        )
+    rc, res = run_module(
+        {
+            "state": "present",
+            "name": "dom0",
+            "properties": {"default_dispvm": "toto"},
+        }
     )
     assert rc == VIRT_FAILED
     assert "Missing default_dispvm" in res
@@ -540,14 +503,12 @@ def test_properties_missing_default_dispvm(qubes):
 
 def test_properties_invalid_volume_name_for_appvm(qubes, vmname, request):
     # volume name not allowed for AppVM
-    rc, res = core(
-        Module(
-            {
-                "state": "present",
-                "name": vmname,
-                "properties": {"volumes": [{"name": "root", "size": 10}]},
-            }
-        )
+    rc, res = run_module(
+        {
+            "state": "present",
+            "name": vmname,
+            "properties": {"volumes": [{"name": "root", "size": 10}]},
+        }
     )
     assert rc == VIRT_FAILED
     assert "Cannot change root volume size for 'AppVM'" in res
@@ -555,27 +516,23 @@ def test_properties_invalid_volume_name_for_appvm(qubes, vmname, request):
 
 def test_properties_missing_volume_fields(qubes, vmname, request):
     # Missing name
-    rc1, res1 = core(
-        Module(
-            {
-                "state": "present",
-                "name": vmname,
-                "properties": {"volumes": [{"size": 10}]},
-            }
-        )
+    rc1, res1 = run_module(
+        {
+            "state": "present",
+            "name": vmname,
+            "properties": {"volumes": [{"size": 10}]},
+        }
     )
     assert rc1 == VIRT_FAILED
     assert "Missing name for the volume" in res1
 
     # Missing size
-    rc2, res2 = core(
-        Module(
-            {
-                "state": "present",
-                "name": vmname,
-                "properties": {"volumes": [{"name": "private"}]},
-            }
-        )
+    rc2, res2 = run_module(
+        {
+            "state": "present",
+            "name": vmname,
+            "properties": {"volumes": [{"name": "private"}]},
+        }
     )
     assert rc2 == VIRT_FAILED
     assert "Missing size for the volume" in res2
@@ -587,34 +544,33 @@ def test_notes(qubes, vmname, request):
         "name": vmname,
         "notes": "For your eyes only",
     }
-    rc, res = core(Module(payload))
+    rc, res = run_module(payload)
     assert rc == VIRT_SUCCESS
     assert qubes.domains[vmname].get_notes() == "For your eyes only"
     # The 2nd call should not change the notes
-    rc, res = core(Module(payload))
+    rc, res = run_module(payload)
     assert rc == VIRT_SUCCESS
     assert not res.get("changed", False)
 
 
+@pytest.mark.xfail(reason="Module sets a default value for tags")
 def test_removetags_errors_if_no_tags_present(qubes, vmname, request):
     request.node.mark_vm_created(vmname)
 
     # Create
-    rc, _ = core(
-        Module({"command": "create", "name": vmname, "vmtype": "AppVM"})
-    )
+    rc, _ = run_module({"command": "create", "name": vmname, "vmtype": "AppVM"})
     assert rc == VIRT_SUCCESS
     assert vmname in qubes.domains
 
     # Remove tags
-    rc, res = core(Module({"command": "removetags", "name": vmname}))
+    rc, res = run_module({"command": "removetags", "name": vmname})
     assert rc == VIRT_FAILED
     assert res["msg"] == "Expected 'tags' parameter to be specified"
 
 
 def test_devices_pci_facts_match_actual(qubes):
     # Gather PCI facts from the module
-    rc, res = core(Module({"gather_device_facts": True}))
+    rc, res = run_module({"gather_device_facts": True})
     assert rc == VIRT_SUCCESS, "Fact‐gathering should succeed"
 
     facts = res["ansible_facts"]
@@ -653,14 +609,12 @@ def test_devices_strict_single_pci_assignment(
     port = latest_net_ports[-1]
 
     # Create VM in strict mode with only one PCI device
-    rc, res = core(
-        Module(
-            {
-                "state": "present",
-                "name": vmname,
-                "devices": [port],
-            }
-        )
+    rc, res = run_module(
+        {
+            "state": "present",
+            "name": vmname,
+            "devices": [port],
+        }
     )
     assert rc == VIRT_SUCCESS
 
@@ -677,7 +631,7 @@ def test_devices_strict_single_pci_assignment(
     assert ports_assigned == [port]
 
     # Clean up
-    core(Module({"state": "absent", "name": vmname}))
+    run_module({"state": "absent", "name": vmname})
 
 
 def test_devices_explicit_strict_assignment(
@@ -687,14 +641,12 @@ def test_devices_explicit_strict_assignment(
     port = latest_net_ports[-1]
 
     # Create VM in strict mode with only one PCI device
-    rc, res = core(
-        Module(
-            {
-                "state": "present",
-                "name": vmname,
-                "devices": {"strategy": "strict", "items": [port]},
-            }
-        )
+    rc, res = run_module(
+        {
+            "state": "present",
+            "name": vmname,
+            "devices": {"strategy": "strict", "items": [port]},
+        }
     )
     assert rc == VIRT_SUCCESS
 
@@ -711,7 +663,7 @@ def test_devices_explicit_strict_assignment(
     assert ports_assigned == [port]
 
     # Clean up
-    core(Module({"state": "absent", "name": vmname}))
+    run_module({"state": "absent", "name": vmname})
 
 
 def test_devices_strict_multiple_with_block(
@@ -721,14 +673,12 @@ def test_devices_strict_multiple_with_block(
     # Use both PCI net devices plus the block device
     devices = [latest_net_ports[-2], latest_net_ports[-1], block_device]
 
-    rc, res = core(
-        Module(
-            {
-                "state": "present",
-                "name": vmname,
-                "devices": devices,
-            }
-        )
+    rc, res = run_module(
+        {
+            "state": "present",
+            "name": vmname,
+            "devices": devices,
+        }
     )
     assert rc == VIRT_SUCCESS
 
@@ -751,7 +701,7 @@ def test_devices_strict_multiple_with_block(
     assert set(pci_ports) == set(latest_net_ports[-2:]), "PCI ports mismatch"
     assert blk_ports == [block_device], "Block device not assigned correctly"
 
-    core(Module({"state": "absent", "name": vmname}))
+    run_module({"state": "absent", "name": vmname})
 
 
 def test_devices_append_strategy_adds_without_removal(
@@ -762,29 +712,25 @@ def test_devices_append_strategy_adds_without_removal(
     second_port = latest_net_ports[-1]
 
     # Initial create with first PCI port
-    rc, _ = core(
-        Module(
-            {
-                "state": "present",
-                "name": vmname,
-                "devices": [first_port],
-            }
-        )
+    rc, _ = run_module(
+        {
+            "state": "present",
+            "name": vmname,
+            "devices": [first_port],
+        }
     )
     assert rc == VIRT_SUCCESS
 
     # Re-run with append strategy: add second PCI and block, keep first
-    rc, _ = core(
-        Module(
-            {
-                "state": "present",
-                "name": vmname,
-                "devices": {
-                    "strategy": "append",
-                    "items": [second_port, block_device],
-                },
-            }
-        )
+    rc, _ = run_module(
+        {
+            "state": "present",
+            "name": vmname,
+            "devices": {
+                "strategy": "append",
+                "items": [second_port, block_device],
+            },
+        }
     )
     assert rc == VIRT_SUCCESS
 
@@ -806,7 +752,7 @@ def test_devices_append_strategy_adds_without_removal(
     assert set(pci_ports) == {first_port, second_port}
     assert blk_ports == [block_device]
 
-    core(Module({"state": "absent", "name": vmname}))
+    run_module({"state": "absent", "name": vmname})
 
 
 def test_devices_per_device_mode_and_options(
@@ -822,14 +768,12 @@ def test_devices_per_device_mode_and_options(
         "options": {"no-strict-reset": True},
     }
 
-    rc, _ = core(
-        Module(
-            {
-                "state": "present",
-                "name": vmname,
-                "devices": [entry],
-            }
-        )
+    rc, _ = run_module(
+        {
+            "state": "present",
+            "name": vmname,
+            "devices": [entry],
+        }
     )
     assert rc == VIRT_SUCCESS
 
@@ -842,7 +786,7 @@ def test_devices_per_device_mode_and_options(
     assert mode == "required"
     assert "no-strict-reset" in opts
 
-    core(Module({"state": "absent", "name": vmname}))
+    run_module({"state": "absent", "name": vmname})
 
 
 def test_devices_strict_idempotent_sync(
@@ -852,27 +796,23 @@ def test_devices_strict_idempotent_sync(
     port = latest_net_ports[-1]
 
     # Initial assignment of a single PCI port
-    rc, res = core(
-        Module(
-            {
-                "state": "present",
-                "name": vmname,
-                "devices": [port],
-            }
-        )
+    rc, res = run_module(
+        {
+            "state": "present",
+            "name": vmname,
+            "devices": [port],
+        }
     )
     assert rc == VIRT_SUCCESS
     assert res.get("changed", False)
 
     # Re-run with the same device list (strict mode) — should be a no-op
-    rc2, res2 = core(
-        Module(
-            {
-                "state": "present",
-                "name": vmname,
-                "devices": [port],
-            }
-        )
+    rc2, res2 = run_module(
+        {
+            "state": "present",
+            "name": vmname,
+            "devices": [port],
+        }
     )
     assert rc2 == VIRT_SUCCESS
     # No changes on the second sync
@@ -893,14 +833,12 @@ def test_devices_strict_unassign_all(qubes, vmname, request, latest_net_ports):
     ports = latest_net_ports[-2:]
 
     # Assign two PCI ports initially
-    rc, res = core(
-        Module(
-            {
-                "state": "present",
-                "name": vmname,
-                "devices": ports,
-            }
-        )
+    rc, res = run_module(
+        {
+            "state": "present",
+            "name": vmname,
+            "devices": ports,
+        }
     )
     assert rc == VIRT_SUCCESS
     assert res.get("changed", False)
@@ -914,14 +852,12 @@ def test_devices_strict_unassign_all(qubes, vmname, request, latest_net_ports):
     assert initial == set(ports)
 
     # Now sync to an empty list (strict default) to remove all devices
-    rc2, res2 = core(
-        Module(
-            {
-                "state": "present",
-                "name": vmname,
-                "devices": [],  # strict empty
-            }
-        )
+    rc2, res2 = run_module(
+        {
+            "state": "present",
+            "name": vmname,
+            "devices": [],  # strict empty
+        }
     )
     assert rc2 == VIRT_SUCCESS
     # Should report that it changed by removing devices
@@ -934,14 +870,12 @@ def test_devices_strict_unassign_all(qubes, vmname, request, latest_net_ports):
     )
 
     # And a second empty-sync is a no-op
-    rc3, res3 = core(
-        Module(
-            {
-                "state": "present",
-                "name": vmname,
-                "devices": [],
-            }
-        )
+    rc3, res3 = run_module(
+        {
+            "state": "present",
+            "name": vmname,
+            "devices": [],
+        }
     )
     assert rc3 == VIRT_SUCCESS
     assert res3.get("changed", False) is False
@@ -951,14 +885,12 @@ def test_services_aliased_to_features_only(qubes, vmname, request):
     request.node.mark_vm_created(vmname)
 
     services = ["clocksync", "minimal-netvm"]
-    rc, res = core(
-        Module(
-            {
-                "state": "present",
-                "name": vmname,
-                "properties": {"services": services},
-            }
-        )
+    rc, res = run_module(
+        {
+            "state": "present",
+            "name": vmname,
+            "properties": {"services": services},
+        }
     )
     assert rc == VIRT_SUCCESS
 
@@ -979,26 +911,22 @@ def test_devices_unchanged(qubes, vmname, request, latest_net_ports):
     port = latest_net_ports[-1]
 
     # Initial assignment of a single PCI port
-    rc, res = core(
-        Module(
-            {
-                "state": "present",
-                "name": vmname,
-                "devices": [port],
-            }
-        )
+    rc, res = run_module(
+        {
+            "state": "present",
+            "name": vmname,
+            "devices": [port],
+        }
     )
     assert rc == VIRT_SUCCESS
     assert res.get("changed", False)
 
     # Re-run without devices, should not change anything
-    rc2, res2 = core(
-        Module(
-            {
-                "state": "present",
-                "name": vmname,
-            }
-        )
+    rc2, res2 = run_module(
+        {
+            "state": "present",
+            "name": vmname,
+        }
     )
     assert rc2 == VIRT_SUCCESS
     # No changes on the second sync
@@ -1021,17 +949,15 @@ def test_services_and_explicit_features_combined(qubes, vmname, request):
     features = {"foo": "bar"}
     services = ["audio", "net"]
 
-    rc, res = core(
-        Module(
-            {
-                "state": "present",
-                "name": vmname,
-                "properties": {
-                    "features": features,
-                    "services": services,
-                },
-            }
-        )
+    rc, res = run_module(
+        {
+            "state": "present",
+            "name": vmname,
+            "properties": {
+                "features": features,
+                "services": services,
+            },
+        }
     )
     assert rc == VIRT_SUCCESS
 
@@ -1055,19 +981,17 @@ def test_lifecycle_shutdown_with_and_without_wait(qubes, vmname, request):
     request.node.mark_vm_created(vmname)
 
     # Create VM
-    rc, _ = core(
-        Module({"command": "create", "name": vmname, "vmtype": "AppVM"})
-    )
+    rc, _ = run_module({"command": "create", "name": vmname, "vmtype": "AppVM"})
     assert rc == VIRT_SUCCESS
     vm = qubes.domains[vmname]
 
     # Start VM
-    rc, _ = core(Module({"command": "start", "name": vmname}))
+    rc, _ = run_module({"command": "start", "name": vmname})
     assert rc == VIRT_SUCCESS
     assert vm.is_running()
 
     # Shutdown without wait (default)
-    rc, _ = core(Module({"state": "shutdown", "name": vmname}))
+    rc, _ = run_module({"state": "shutdown", "name": vmname})
     assert rc == VIRT_SUCCESS
     # vm is not halted yet
     assert not vm.is_halted()
@@ -1076,12 +1000,12 @@ def test_lifecycle_shutdown_with_and_without_wait(qubes, vmname, request):
     assert vm.is_halted()
 
     # Restart for the next check
-    rc, _ = core(Module({"command": "start", "name": vmname}))
+    rc, _ = run_module({"command": "start", "name": vmname})
     assert rc == VIRT_SUCCESS
     assert vm.is_running()
 
     # Shutdown with wait=True
-    rc, _ = core(Module({"state": "shutdown", "name": vmname, "wait": True}))
+    rc, _ = run_module({"state": "shutdown", "name": vmname, "wait": True})
     assert rc == VIRT_SUCCESS
     # should already be halted, no extra sleep needed
     assert vm.is_halted()
@@ -1090,14 +1014,12 @@ def test_lifecycle_shutdown_with_and_without_wait(qubes, vmname, request):
 def test_properties_set_kernelopts(qubes, vmname, request):
     request.node.mark_vm_created(vmname)
     props = {"kernelopts": "swiotlb=4096 foo=bar"}
-    rc, res = core(
-        Module(
-            {
-                "state": "present",
-                "name": vmname,
-                "properties": props,
-            }
-        )
+    rc, res = run_module(
+        {
+            "state": "present",
+            "name": vmname,
+            "properties": props,
+        }
     )
     assert rc == VIRT_SUCCESS
     assert "kernelopts" in res["Properties updated"]
@@ -1107,14 +1029,12 @@ def test_properties_set_kernelopts(qubes, vmname, request):
 def test_properties_set_timeouts(qubes, vmname, request):
     request.node.mark_vm_created(vmname)
     props = {"qrexec_timeout": 123, "shutdown_timeout": 456}
-    rc, res = core(
-        Module(
-            {
-                "state": "present",
-                "name": vmname,
-                "properties": props,
-            }
-        )
+    rc, res = run_module(
+        {
+            "state": "present",
+            "name": vmname,
+            "properties": props,
+        }
     )
     assert rc == VIRT_SUCCESS
     updated = res["Properties updated"]
@@ -1133,14 +1053,12 @@ def test_properties_set_ip_ip6_and_mac(qubes, vmname, request):
         "ip6": "fe80::1",
         "mac": "00:11:22:33:44:55",
     }
-    rc, res = core(
-        Module(
-            {
-                "state": "present",
-                "name": vmname,
-                "properties": props,
-            }
-        )
+    rc, res = run_module(
+        {
+            "state": "present",
+            "name": vmname,
+            "properties": props,
+        }
     )
     assert rc == VIRT_SUCCESS
     updated = res["Properties updated"]
@@ -1158,14 +1076,12 @@ def test_properties_set_management_dispvm_and_audiovm(
 ):
     request.node.mark_vm_created(vmname)
     props = {"management_dispvm": managementdvm.name, "audiovm": audiovm.name}
-    rc, res = core(
-        Module(
-            {
-                "state": "present",
-                "name": vmname,
-                "properties": props,
-            }
-        )
+    rc, res = run_module(
+        {
+            "state": "present",
+            "name": vmname,
+            "properties": props,
+        }
     )
     assert rc == VIRT_SUCCESS
     updated = res["Properties updated"]
@@ -1180,14 +1096,12 @@ def test_properties_set_management_dispvm_and_audiovm(
 def test_properties_set_default_user_and_guivm(qubes, vmname, guivm, request):
     request.node.mark_vm_created(vmname)
     props = {"default_user": "alice", "guivm": guivm.name}
-    rc, res = core(
-        Module(
-            {
-                "state": "present",
-                "name": vmname,
-                "properties": props,
-            }
-        )
+    rc, res = run_module(
+        {
+            "state": "present",
+            "name": vmname,
+            "properties": props,
+        }
     )
     assert rc == VIRT_SUCCESS
     updated = res["Properties updated"]
@@ -1202,104 +1116,88 @@ def test_properties_set_default_user_and_guivm(qubes, vmname, guivm, request):
 def test_properties_invalid_type_for_new_properties(qubes, vmname, request):
     request.node.mark_vm_created(vmname)
     # ip must be str, not int
-    rc, res = core(
-        Module(
-            {
-                "state": "present",
-                "name": vmname,
-                "properties": {"ip": 12345},
-            }
-        )
+    rc, res = run_module(
+        {
+            "state": "present",
+            "name": vmname,
+            "properties": {"ip": 12345},
+        }
     )
     assert rc == VIRT_FAILED
     assert "Invalid property value type" in res
     # qrexec_timeout must be int, not str
-    rc2, res2 = core(
-        Module(
-            {
-                "state": "present",
-                "name": vmname,
-                "properties": {"qrexec_timeout": "sixty"},
-            }
-        )
+    rc2, res2 = run_module(
+        {
+            "state": "present",
+            "name": vmname,
+            "properties": {"qrexec_timeout": "sixty"},
+        }
     )
     assert rc2 == VIRT_FAILED
     assert "Invalid property value type" in res2
 
 
 def test_set_property_to_empty_string(vm, qubes):
-    rc, _ = core(
-        Module(
-            {
-                "state": "present",
-                "name": vm.name,
-                "properties": {"netvm": "sys-net"},
-            }
-        )
+    rc, _ = run_module(
+        {
+            "state": "present",
+            "name": vm.name,
+            "properties": {"netvm": "sys-net"},
+        }
     )
     assert rc == VIRT_SUCCESS
     assert qubes.domains[vm.name].netvm == "sys-net"
 
-    rc, _ = core(
-        Module(
-            {
-                "state": "present",
-                "name": vm.name,
-                "properties": {"netvm": ""},
-            }
-        )
+    rc, _ = run_module(
+        {
+            "state": "present",
+            "name": vm.name,
+            "properties": {"netvm": ""},
+        }
     )
     assert rc == VIRT_SUCCESS
     assert qubes.domains[vm.name].netvm == None
 
 
 def test_set_property_to_none(vm, qubes):
-    rc, _ = core(
-        Module(
-            {
-                "state": "present",
-                "name": vm.name,
-                "properties": {"netvm": "sys-net"},
-            }
-        )
+    rc, _ = run_module(
+        {
+            "state": "present",
+            "name": vm.name,
+            "properties": {"netvm": "sys-net"},
+        }
     )
     assert rc == VIRT_SUCCESS
     assert qubes.domains[vm.name].netvm == "sys-net"
 
-    rc, _ = core(
-        Module(
-            {
-                "state": "present",
-                "name": vm.name,
-                "properties": {"netvm": None},
-            }
-        )
+    rc, _ = run_module(
+        {
+            "state": "present",
+            "name": vm.name,
+            "properties": {"netvm": None},
+        }
     )
     assert rc == VIRT_SUCCESS
     assert qubes.domains[vm.name].netvm == None
 
 
 def test_set_property_to_none_str(vm, qubes):
-    rc, _ = core(
-        Module(
-            {
-                "state": "present",
-                "name": vm.name,
-                "properties": {"netvm": "sys-net"},
-            }
-        )
+    rc, _ = run_module(
+        {
+            "state": "present",
+            "name": vm.name,
+            "properties": {"netvm": "sys-net"},
+        }
     )
     assert rc == VIRT_SUCCESS
     assert qubes.domains[vm.name].netvm == "sys-net"
 
-    rc, _ = core(
-        Module(
-            {
-                "state": "present",
-                "name": vm.name,
-                "properties": {"netvm": "None"},
-            }
-        )
+    rc, _ = run_module(
+        {
+            "state": "present",
+            "name": vm.name,
+            "properties": {"netvm": "None"},
+        }
     )
     assert rc == VIRT_SUCCESS
     assert qubes.domains[vm.name].netvm == None
@@ -1307,14 +1205,12 @@ def test_set_property_to_none_str(vm, qubes):
 
 def test_create_vm_which_is_its_self_dispvm(vmname, request, qubes):
     request.node.mark_vm_created(vmname)
-    rc, _ = core(
-        Module(
-            {
-                "state": "present",
-                "name": vmname,
-                "properties": {"default_dispvm": vmname},
-            }
-        )
+    rc, _ = run_module(
+        {
+            "state": "present",
+            "name": vmname,
+            "properties": {"default_dispvm": vmname},
+        }
     )
 
     assert rc == VIRT_SUCCESS
@@ -1323,8 +1219,8 @@ def test_create_vm_which_is_its_self_dispvm(vmname, request, qubes):
 
 def test_label_change(vmname, request, qubes):
     request.node.mark_vm_created(vmname)
-    rc, returned_data = core(
-        Module({"state": "present", "name": vmname, "label": "yellow"})
+    rc, returned_data = run_module(
+        {"state": "present", "name": vmname, "label": "yellow"}
     )
     assert rc == VIRT_SUCCESS
     assert str(qubes.domains[vmname].label) == "yellow"
@@ -1332,8 +1228,8 @@ def test_label_change(vmname, request, qubes):
     assert returned_data["created"]
     assert returned_data["diff"]["after"]["properties"]["label"] == "yellow"
 
-    rc, returned_data = core(
-        Module({"state": "present", "name": vmname, "label": "green"})
+    rc, returned_data = run_module(
+        {"state": "present", "name": vmname, "label": "green"}
     )
     assert rc == VIRT_SUCCESS
     assert str(qubes.domains[vmname].label) == "green"
@@ -1346,15 +1242,15 @@ def test_label_change(vmname, request, qubes):
 def test_label_should_be_changed_only_when_specified(vmname, request, qubes):
     request.node.mark_vm_created(vmname)
 
-    rc, returned_data = core(
-        Module({"state": "present", "name": vmname, "label": "yellow"})
+    rc, returned_data = run_module(
+        {"state": "present", "name": vmname, "label": "yellow"}
     )
     assert rc == VIRT_SUCCESS
     assert str(qubes.domains[vmname].label) == "yellow"
     assert returned_data["changed"]
     assert returned_data["diff"]["after"]["properties"]["label"] == "yellow"
 
-    rc, returned_data = core(Module({"state": "present", "name": vmname}))
+    rc, returned_data = run_module({"state": "present", "name": vmname})
     assert rc == VIRT_SUCCESS
     qubes.domains.refresh_cache(force=True)
     assert str(qubes.domains[vmname].label) == "yellow"
@@ -1367,33 +1263,56 @@ def test_setting_qube_value_to_the_same_value_than_default(vm):
     assert vm.property_is_default("netvm")
     netvm = vm.netvm.name
 
-    mod = Module(
-        {
-            "state": "present",
-            "name": vm.name,
-            "properties": {"netvm": netvm},
-        }
-    )
-    rc, returned_data = core(mod)
+    params = {
+        "state": "present",
+        "name": vm.name,
+        "properties": {"netvm": netvm},
+    }
+    rc, returned_data = run_module(params)
     assert rc == VIRT_SUCCESS, returned_data
     assert returned_data["changed"]
     assert vm.netvm == netvm
     assert not vm.property_is_default("netvm")
 
     # Idempotence
-    rc, returned_data = core(mod)
+    rc, returned_data = run_module(params)
     assert rc == VIRT_SUCCESS, returned_data
     assert not returned_data["changed"]
 
-    mod = Module(
-        {
-            "state": "present",
-            "name": vm.name,
-            "properties": {"netvm": "*default*"},
-        }
-    )
-    rc, returned_data = core(mod)
+    params = {
+        "state": "present",
+        "name": vm.name,
+        "properties": {"netvm": "*default*"},
+    }
+    rc, returned_data = run_module(params)
     assert rc == VIRT_SUCCESS, returned_data
     assert returned_data["changed"]
     assert vm.netvm == netvm
     assert vm.property_is_default("netvm")
+
+
+def test_no_vm_klass_should_no_try_to_convert_to_appvm(request, vmname, qubes):
+    request.node.mark_vm_created(vmname)
+    rc, _ = run_module(
+        {
+            "state": "present",
+            "name": vmname,
+            "vmtype": "StandaloneVM",
+            "template": qubes.default_template.name,
+        }
+    )
+
+    assert rc == VIRT_SUCCESS
+    assert qubes.domains[vmname].klass == "StandaloneVM"
+
+    # Start qube without specifying its klass — must NOT try to convert to AppVM
+    rc, _ = run_module(
+        {
+            "state": "running",
+            "name": vmname,
+        }
+    )
+
+    assert rc == VIRT_SUCCESS
+    assert qubes.domains[vmname].get_power_state() == "Running"
+    assert qubes.domains[vmname].klass == "StandaloneVM"

--- a/tests/qubes/test_module_command.py
+++ b/tests/qubes/test_module_command.py
@@ -2,25 +2,20 @@ import os
 import time
 
 import pytest
-import qubesadmin
 
-from ansible_collections.qubesos.core.plugins.module_utils.qubes_module_command import (
-    core,
+from tests.qubes.ansible_test_utils import (
+    AnsibleFailJson,
+    run_module_qubesos_core_command as run_module,
 )
-from tests.qubes.conftest import qubes, vmname, Module, ModuleExitWithError
+
+from tests.qubes.conftest import qubes, vmname
 
 
 def test_unrecognized_command():
     # Create
-    fake_module = Module({"command": "foo"})
-    try:
-        core(fake_module)
-    except ModuleExitWithError:
-        assert (
-            fake_module.returned_data["msg"] == "Command 'foo' not recognized"
-        )
-    else:
-        pytest.fail("Module should have raised an error")
+    with pytest.raises(AnsibleFailJson) as exc:
+        run_module({"command": "foo"})
+    assert "value of command must be one of" in exc.value.args[0]["msg"]
 
 
 def test_lifecycle_full_create_start_shutdown_remove(qubes, vmname, request):
@@ -28,25 +23,22 @@ def test_lifecycle_full_create_start_shutdown_remove(qubes, vmname, request):
     request.node.mark_vm_created(vmname)
 
     # Create
-    fake_module = Module(
-        {"command": "create", "name": vmname, "vmtype": "AppVM"}
-    )
-    core(fake_module)
-    assert fake_module.returned_data["created"] == vmname
+    res = run_module({"command": "create", "name": vmname, "vmtype": "AppVM"})
+    assert res["created"] == vmname
     assert vmname in qubes.domains
 
     # Start
-    core(Module({"command": "start", "name": vmname}))
+    run_module({"command": "start", "name": vmname})
     vm = qubes.domains[vmname]
     assert vm.is_running()
 
     # Shutdown
-    core(Module({"command": "shutdown", "name": vmname}))
+    run_module({"command": "shutdown", "name": vmname})
     time.sleep(5)
     assert vm.is_halted()
 
     # Remove
-    core(Module({"command": "remove", "name": vmname}))
+    run_module({"command": "remove", "name": vmname})
     qubes.domains.refresh_cache(force=True)
     assert vmname not in qubes.domains
 
@@ -55,50 +47,51 @@ def test_lifecycle_create_and_absent(qubes, vmname, request):
     request.node.mark_vm_created(vmname)
 
     # Create
-    core(Module({"command": "create", "name": vmname, "vmtype": "AppVM"}))
+    run_module({"command": "create", "name": vmname, "vmtype": "AppVM"})
     assert vmname in qubes.domains
 
     # Absent
-    core(Module({"command": "remove", "name": vmname}))
+    run_module({"command": "remove", "name": vmname})
     qubes.domains.refresh_cache(force=True)
     assert vmname not in qubes.domains
 
 
 def test_lifecycle_pause_and_resume(qubes, vmname, request):
     request.node.mark_vm_created(vmname)
-    core(Module({"command": "create", "name": vmname, "vmtype": "AppVM"}))
-    core(Module({"command": "start", "name": vmname}))
+    run_module({"command": "create", "name": vmname, "vmtype": "AppVM"})
+    run_module({"command": "start", "name": vmname})
     time.sleep(1)
 
-    core(Module({"command": "pause", "name": vmname}))
+    run_module({"command": "pause", "name": vmname})
     assert qubes.domains[vmname].is_paused()
 
-    core(Module({"command": "unpause", "name": vmname}))
+    run_module({"command": "unpause", "name": vmname})
     assert qubes.domains[vmname].is_running()
 
     # Clean up
-    core(Module({"command": "destroy", "name": vmname}))
-    core(Module({"command": "remove", "name": vmname}))
+    run_module({"command": "destroy", "name": vmname})
+    run_module({"command": "remove", "name": vmname})
 
 
 def test_lifecycle_status_reporting(qubes, vmname, request):
     request.node.mark_vm_created(vmname)
-    fake_module = Module({"command": "status", "name": vmname})
 
-    core(Module({"command": "create", "name": vmname, "vmtype": "AppVM"}))
-    core(fake_module)
-    assert fake_module.returned_data["status"] == "shutdown"
+    status_params = {"command": "status", "name": vmname}
 
-    core(Module({"command": "start", "name": vmname}))
-    core(fake_module)
-    assert fake_module.returned_data["status"] == "running"
+    run_module({"command": "create", "name": vmname, "vmtype": "AppVM"})
+    res = run_module(status_params)
+    assert res["status"] == "shutdown"
 
-    core(Module({"command": "destroy", "name": vmname}))
-    core(fake_module)
-    assert fake_module.returned_data["status"] == "shutdown"
+    run_module({"command": "start", "name": vmname})
+    res = run_module(status_params)
+    assert res["status"] == "running"
+
+    run_module({"command": "destroy", "name": vmname})
+    res = run_module(status_params)
+    assert res["status"] == "shutdown"
     assert qubes.domains[vmname].get_power_state() == "Halted"
 
-    core(Module({"command": "remove", "name": vmname}))
+    run_module({"command": "remove", "name": vmname})
 
 
 def test_create_clone_vmtype_combinations(qubes, vmname, request):
@@ -108,72 +101,68 @@ def test_create_clone_vmtype_combinations(qubes, vmname, request):
     # request.node.mark_vm_created(f"{vmname}-clone-standalonevm")
 
     # Test creating / cloning from AppVM
-    core(Module({"command": "create", "name": vmname, "vmtype": "AppVM"}))
-    core(
-        Module(
-            {
-                "command": "create",
-                "name": f"{vmname}-clone-appvm",
-                "template": vmname,
-                "vmtype": "AppVM",
-            }
-        )
+    run_module({"command": "create", "name": vmname, "vmtype": "AppVM"})
+    run_module(
+        {
+            "command": "create",
+            "name": f"{vmname}-clone-appvm",
+            "template": vmname,
+            "vmtype": "AppVM",
+        }
     )
 
     assert f"{vmname}-clone-appvm" in qubes.domains
 
-    # rc, _ = core(Module({"command": "create", "name": f"{vmname}-clone-templatevm", "template": vmname, "vmtype": "TemplateVM"}))
+    # rc, _ = run_module({"command": "create", "name": f"{vmname}-clone-templatevm", "template": vmname, "vmtype": "TemplateVM"})
     # assert rc == VIRT_SUCCESS
     # assert f"{vmname}-clone-templatevm" in qubes.domains
 
-    # rc, _ = core(Module({"command": "create", "name": f"{vmname}-clone-standalonevm", "template": vmname, "vmtype": "StandaloneVM"}))
+    # rc, _ = run_module({"command": "create", "name": f"{vmname}-clone-standalonevm", "template": vmname, "vmtype": "StandaloneVM"})
     # assert rc == VIRT_SUCCESS
     # assert f"{vmname}-clone-standalonevm" in qubes.domains
 
     # Test creating / cloning from TemplateVM
-    core(Module({"command": "create", "name": vmname, "vmtype": "TemplateVM"}))
-    core(
-        Module(
-            {
-                "command": "create",
-                "name": f"{vmname}-clone-appvm",
-                "template": vmname,
-                "vmtype": "AppVM",
-            }
-        )
+    run_module({"command": "create", "name": vmname, "vmtype": "TemplateVM"})
+    run_module(
+        {
+            "command": "create",
+            "name": f"{vmname}-clone-appvm",
+            "template": vmname,
+            "vmtype": "AppVM",
+        }
     )
 
     assert f"{vmname}-clone-appvm" in qubes.domains
     #
-    # rc, _ = core(Module({"command": "create", "name": f"{vmname}-clone-templatevm", "template": vmname, "vmtype": "TemplateVM"}))
+    # rc, _ = run_module({"command": "create", "name": f"{vmname}-clone-templatevm", "template": vmname, "vmtype": "TemplateVM"})
     #
     # assert rc == VIRT_SUCCESS
     # assert f"{vmname}-clone-templatevm" in qubes.domains
     #
-    # rc, _ = core(Module({"command": "create", "name": f"{vmname}-clone-standalonevm", "template": vmname, "vmtype": "StandaloneVM"}))
+    # rc, _ = run_module({"command": "create", "name": f"{vmname}-clone-standalonevm", "template": vmname, "vmtype": "StandaloneVM"})
     #
     # assert rc == VIRT_SUCCESS
     # assert f"{vmname}-clone-standalonevm" in qubes.domains
     #
     # # Test creating / cloning from StandaloneVM
-    # core(Module({"command": "create", "name": vmname, "vmtype": "StandaloneVM"}))
-    # rc, _ = core(Module({"command": "create", "name": f"{vmname}-clone-appvm", "template": vmname, "vmtype": "AppVM"}))
+    # run_module({"command": "create", "name": vmname, "vmtype": "StandaloneVM"})
+    # rc, _ = run_module({"command": "create", "name": f"{vmname}-clone-appvm", "template": vmname, "vmtype": "AppVM"})
     # assert rc == VIRT_SUCCESS
     # assert f"{vmname}-clone-appvm" in qubes.domains
     #
-    # rc, _ = core(Module({"command": "create", "name": f"{vmname}-clone-templatevm", "template": vmname, "vmtype": "TemplateVM"}))
+    # rc, _ = run_module({"command": "create", "name": f"{vmname}-clone-templatevm", "template": vmname, "vmtype": "TemplateVM"})
     # assert rc == VIRT_SUCCESS
     # assert f"{vmname}-clone-templatevm" in qubes.domains
     #
-    # rc, _ = core(Module({"command": "create", "name": f"{vmname}-clone-standalonevm", "template": vmname, "vmtype": "StandaloneVM"}))
+    # rc, _ = run_module({"command": "create", "name": f"{vmname}-clone-standalonevm", "template": vmname, "vmtype": "StandaloneVM"})
     # assert rc == VIRT_SUCCESS
     # assert f"{vmname}-clone-standalonevm" in qubes.domains
     #
     # Cleanup
-    core(Module({"command": "remove", "name": f"{vmname}-clone-appvm"}))
-    # core(Module({"state": "absent", "name": f"{vmname}-clone-templatevm"}))
-    # core(Module({"state": "absent", "name": f"{vmname}-clone-standalonevm"}))
-    core(Module({"command": "remove", "name": vmname}))
+    run_module({"command": "remove", "name": f"{vmname}-clone-appvm"})
+    # run_module({"state": "absent", "name": f"{vmname}-clone-templatevm"})
+    # run_module({"state": "absent", "name": f"{vmname}-clone-standalonevm"})
+    run_module({"command": "remove", "name": vmname})
 
 
 def test_inventory_generation_and_grouping(tmp_path, qubes):
@@ -181,15 +170,13 @@ def test_inventory_generation_and_grouping(tmp_path, qubes):
     os.chdir(tmp_path)
 
     # Create a standalone VM (by default we don't have any)
-    core(
-        Module(
-            {
-                "command": "create",
-                "name": "teststandalone",
-                "vmtype": "StandaloneVM",
-                "template": "debian-13-xfce",
-            }
-        )
+    run_module(
+        {
+            "command": "create",
+            "name": "teststandalone",
+            "vmtype": "StandaloneVM",
+            "template": "debian-13-xfce",
+        }
     )
 
     # Collect expected VMs by class
@@ -200,9 +187,8 @@ def test_inventory_generation_and_grouping(tmp_path, qubes):
         expected.setdefault(vm.klass, []).append(vm.name)
 
     # Run createinventory
-    fake_module = Module({"command": "createinventory"})
-    core(fake_module)
-    assert fake_module.returned_data["status"] == "successful"
+    res = run_module({"command": "createinventory"})
+    assert res["status"] == "successful"
 
     inv_file = tmp_path / "inventory"
     assert inv_file.exists()
@@ -229,37 +215,27 @@ def test_inventory_generation_and_grouping(tmp_path, qubes):
     assert set(standalonevms) == set(expected.get("StandaloneVM", []))
 
 
+@pytest.mark.xfail(reason="Module sets a default value for tags")
 def test_removetags_errors_if_no_tags_present(qubes, vmname, request):
     request.node.mark_vm_created(vmname)
 
     # Create
-    fake_module = Module(
-        {"command": "create", "name": vmname, "vmtype": "AppVM"}
-    )
-    core(fake_module)
+    run_module({"command": "create", "name": vmname, "vmtype": "AppVM"})
     assert vmname in qubes.domains
 
     # Remove tags
-    fake_module = Module({"command": "removetags", "name": vmname})
-    try:
-        core(fake_module)
-
-    except ModuleExitWithError:
-        assert (
-            fake_module.returned_data["msg"]
-            == "Expected 'tags' parameter to be specified"
-        )
-    else:
-        pytest.fail("Module should have raised an error")
+    with pytest.raises(AnsibleFailJson) as exc:
+        run_module({"command": "removetags", "name": vmname})
+    assert (
+        exc.value.args[0]["msg"] == "Expected 'tags' parameter to be specified"
+    )
 
 
 def test_list_vms_command(vm):
-    fake_module = Module({"command": "list_vms", "state": "shutdown"})
-    core(fake_module)
-    assert vm.name in fake_module.returned_data["list_vms"]
+    res = run_module({"command": "list_vms", "state": "shutdown"})
+    assert vm.name in res["list_vms"]
 
 
 def test_get_states_command(vm):
-    fake_module = Module({"command": "get_states"})
-    core(fake_module)
-    assert f"{vm.name} shutdown" in fake_module.returned_data["states"]
+    res = run_module({"command": "get_states"})
+    assert f"{vm.name} shutdown" in res["states"]

--- a/tests/qubes/test_module_qube.py
+++ b/tests/qubes/test_module_qube.py
@@ -1,11 +1,9 @@
-import os
 import pytest
-import time
 
-from ansible_collections.qubesos.core.plugins.module_utils.qubes_module_qube import (
-    QubeModule,
+from tests.qubes.ansible_test_utils import (
+    AnsibleFailJson,
+    run_module_qubesos_core_qube_main as run_module,
 )
-from tests.qubes.conftest import qubes, vmname, Module, ModuleExitWithError
 
 
 def test_lifecycle_full_create_start_shutdown_remove(qubes, vmname, request):
@@ -13,59 +11,55 @@ def test_lifecycle_full_create_start_shutdown_remove(qubes, vmname, request):
     request.node.mark_vm_created(vmname)
 
     # Create
-    fake_module = Module({"state": "present", "name": vmname, "klass": "AppVM"})
-    QubeModule(fake_module).run()
+    result = run_module({"state": "present", "name": vmname, "klass": "AppVM"})
 
-    assert fake_module.returned_data.get("changed")
+    assert result.get("changed")
     assert vmname in qubes.domains
     assert qubes.domains[vmname].is_halted()
-    assert fake_module.returned_data["created"]
+    assert result["created"]
 
-    fake_module = Module({"state": "running", "name": vmname})
-    QubeModule(fake_module).run()
+    result = run_module({"state": "running", "name": vmname})
     assert qubes.domains[vmname].is_running()
-    assert fake_module.returned_data.get("changed")
+    assert result.get("changed")
 
     # Shutdown
-    fake_module = Module({"state": "halted", "name": vmname})
-    QubeModule(fake_module).run()
+    result = run_module({"state": "halted", "name": vmname})
     assert qubes.domains[vmname].is_halted()
-    assert fake_module.returned_data.get("changed")
+    assert result.get("changed")
 
     # Remove
-    fake_module = Module({"state": "absent", "name": vmname})
-    QubeModule(fake_module).run()
+    result = run_module({"state": "absent", "name": vmname})
     qubes.domains.refresh_cache(force=True)
     assert vmname not in qubes.domains
-    assert fake_module.returned_data.get("changed")
+    assert result.get("changed")
 
 
 def test_lifecycle_create_and_absent(qubes, vmname, request):
     request.node.mark_vm_created(vmname)
 
     # Create
-    fake_module = Module({"state": "present", "name": vmname})
-    QubeModule(fake_module).run()
-    assert fake_module.returned_data.get("changed")
+    result = run_module({"state": "present", "name": vmname})
+    assert result.get("changed")
     assert vmname in qubes.domains
 
     # Absent
-    fake_module = Module({"state": "absent", "name": vmname})
-    QubeModule(fake_module).run()
+    result = run_module({"state": "absent", "name": vmname})
     qubes.domains.refresh_cache(force=True)
     assert vmname not in qubes.domains
-    assert fake_module.returned_data.get("changed")
+    assert result.get("changed")
 
 
 def test_lifecycle_create_running_vm(qubes, vmname, request):
     request.node.mark_vm_created(vmname)
 
-    # Create
-    fake_module = Module(
-        {"state": "running", "name": vmname, "tags": ["a", "b"]}
+    result = run_module(
+        {
+            "state": "running",
+            "name": vmname,
+            "tags": ["a", "b"],
+        }
     )
-    QubeModule(fake_module).run()
-    assert fake_module.returned_data.get("changed")
+    assert result.get("changed")
     assert vmname in qubes.domains
     vm = qubes.domains[vmname]
     assert vm.is_running()
@@ -76,23 +70,19 @@ def test_lifecycle_create_running_vm(qubes, vmname, request):
 def test_lifecycle_pause_and_resume(qubes, vmname, request):
     request.node.mark_vm_created(vmname)
 
-    # create and start
-    fake_module = Module({"state": "running", "name": vmname})
-    QubeModule(fake_module).run()
-    assert fake_module.returned_data.get("changed")
+    result = run_module({"state": "running", "name": vmname})
+    assert result.get("changed")
     assert vmname in qubes.domains
     vm = qubes.domains[vmname]
     assert vm.get_power_state() == "Running"
 
-    fake_module = Module({"state": "paused", "name": vmname})
-    QubeModule(fake_module).run()
-    assert fake_module.returned_data.get("changed")
+    result = run_module({"state": "paused", "name": vmname})
+    assert result.get("changed")
     vm = qubes.domains[vmname]
     assert vm.get_power_state() == "Paused"
 
-    fake_module = Module({"state": "running", "name": vmname})
-    QubeModule(fake_module).run()
-    assert fake_module.returned_data.get("changed")
+    result = run_module({"state": "running", "name": vmname})
+    assert result.get("changed")
     vm = qubes.domains[vmname]
     assert vm.get_power_state() == "Running"
 
@@ -111,12 +101,11 @@ def test_create_clone_vmtype_combinations(qubes, vmname, request):
     request.node.mark_vm_created(standalone_clone_name_2)
 
     # 1- create an AppVM
-    fake_module = Module({"state": "present", "name": vmname, "klass": "AppVM"})
-    QubeModule(fake_module).run()
-    assert fake_module.returned_data["created"]
+    result = run_module({"state": "present", "name": vmname, "klass": "AppVM"})
+    assert result["created"]
 
     # 2- Clone this AppVM
-    fake_module = Module(
+    result = run_module(
         {
             "state": "present",
             "name": appvm_clone_name,
@@ -124,29 +113,27 @@ def test_create_clone_vmtype_combinations(qubes, vmname, request):
             "clone_src": vmname,
         }
     )
-    QubeModule(fake_module).run()
     qubes.domains.refresh_cache(force=True)
-    assert fake_module.returned_data["created"]
+    assert result["created"]
     assert appvm_clone_name in qubes.domains
     assert qubes.domains[appvm_clone_name].klass == "AppVM"
 
     # 3- Clone a template
-    fake_module = Module(
+    result = run_module(
         {
             "state": "present",
             "name": template_clone_name,
             "klass": "TemplateVM",
-            "clone_src": qubes.default_template,
+            "clone_src": qubes.default_template.name,
         }
     )
-    QubeModule(fake_module).run()
     qubes.domains.refresh_cache(force=True)
-    assert fake_module.returned_data["created"]
+    assert result["created"]
     assert template_clone_name in qubes.domains
     assert qubes.domains[template_clone_name].klass == "TemplateVM"
 
     # 4- Create a Standalone VM from that template
-    fake_module = Module(
+    result = run_module(
         {
             "state": "present",
             "name": standalone_clone_name_1,
@@ -154,14 +141,13 @@ def test_create_clone_vmtype_combinations(qubes, vmname, request):
             "clone_src": template_clone_name,
         }
     )
-    QubeModule(fake_module).run()
     qubes.domains.refresh_cache(force=True)
-    assert fake_module.returned_data["created"]
+    assert result["created"]
     assert standalone_clone_name_1 in qubes.domains
     assert qubes.domains[standalone_clone_name_1].klass == "StandaloneVM"
 
     # 5- Clone this StandaloneVM
-    fake_module = Module(
+    result = run_module(
         {
             "state": "present",
             "name": standalone_clone_name_2,
@@ -169,15 +155,14 @@ def test_create_clone_vmtype_combinations(qubes, vmname, request):
             "clone_src": standalone_clone_name_1,
         }
     )
-    QubeModule(fake_module).run()
     qubes.domains.refresh_cache(force=True)
-    assert fake_module.returned_data["created"]
+    assert result["created"]
     assert standalone_clone_name_2 in qubes.domains
     assert qubes.domains[standalone_clone_name_2].klass == "StandaloneVM"
 
     # 6- Last check, we want to clone an AppVM (to the data on the private
     #    volume for example, but we want to use another template)
-    fake_module = Module(
+    result = run_module(
         {
             "state": "present",
             "name": appvm_clone_name_2,
@@ -186,9 +171,8 @@ def test_create_clone_vmtype_combinations(qubes, vmname, request):
             "template": template_clone_name,
         }
     )
-    QubeModule(fake_module).run()
     qubes.domains.refresh_cache(force=True)
-    assert fake_module.returned_data["created"]
+    assert result["created"]
     assert appvm_clone_name_2 in qubes.domains
     vm = qubes.domains[appvm_clone_name_2]
     assert vm.template == qubes.domains[template_clone_name]
@@ -198,19 +182,18 @@ def test_create_clone_vmtype_combinations(qubes, vmname, request):
 def test_volumes_list_for_standalonevm(qubes, vmname, request):
     request.node.mark_vm_created(vmname)
 
-    fake_module = Module(
+    run_module(
         {
             "state": "present",
             "name": vmname,
             "klass": "StandaloneVM",
-            "clone_src": qubes.default_template,
+            "clone_src": qubes.default_template.name,
             "volumes": {
                 "root": {"size": 32212254720},
                 "private": {"size": 10737418240, "revisions_to_keep": 123},
             },
         }
     )
-    QubeModule(fake_module).run()
 
     vm = qubes.domains[vmname]
     assert vm.klass == "StandaloneVM"
@@ -220,7 +203,7 @@ def test_volumes_list_for_standalonevm(qubes, vmname, request):
 
     # Resize root
     # Change revisions to keep
-    fake_module = Module(
+    result = run_module(
         {
             "state": "present",
             "name": vmname,
@@ -232,9 +215,8 @@ def test_volumes_list_for_standalonevm(qubes, vmname, request):
             },
         }
     )
-    QubeModule(fake_module).run()
 
-    assert fake_module.returned_data["diff"] == {
+    assert result["diff"] == {
         "before": {
             "volumes": {
                 "root": {"size": 32212254720},
@@ -266,13 +248,12 @@ def test_properties_and_features_set_and_tag_vm(qubes, vmname, request):
         "tags": tags,
         "notes": "For your eyes only",
     }
-    fake_module = Module(params)
-    QubeModule(fake_module).run()
+    result = run_module(params)
 
     vm = qubes.domains[vmname]
-    props_new_values = fake_module.returned_data["diff"]["after"]["properties"]
-    feats_new_values = fake_module.returned_data["diff"]["after"]["features"]
-    tags_new_values = fake_module.returned_data["diff"]["after"]["tags"]
+    props_new_values = result["diff"]["after"]["properties"]
+    feats_new_values = result["diff"]["after"]["features"]
+    tags_new_values = result["diff"]["after"]["tags"]
 
     assert vm.autostart is True
     assert props_new_values["autostart"] is True
@@ -293,26 +274,23 @@ def test_properties_and_features_set_and_tag_vm(qubes, vmname, request):
         assert t in tags_new_values
 
     assert vm.get_notes() == "For your eyes only"
-    assert (
-        fake_module.returned_data["diff"]["after"]["notes"]
-        == "For your eyes only"
-    )
+    assert result["diff"]["after"]["notes"] == "For your eyes only"
 
     # test if updating tags work
     tags = ["tag3", "tag4"]
-    params = {
-        "state": "present",
-        "name": vmname,
-        "tags": tags,
-    }
-    fake_module = Module(params)
-    QubeModule(fake_module).run()
+    result = run_module(
+        {
+            "state": "present",
+            "name": vmname,
+            "tags": tags,
+        }
+    )
     for t in tags:
         assert t in qubes.domains[vmname].tags
-        assert t not in fake_module.returned_data["diff"]["before"]["tags"]
-        assert t in fake_module.returned_data["diff"]["after"]["tags"]
+        assert t not in result["diff"]["before"]["tags"]
+        assert t in result["diff"]["after"]["tags"]
 
-    fake_module = Module(
+    result = run_module(
         {
             "state": "present",
             "name": vmname,
@@ -322,14 +300,13 @@ def test_properties_and_features_set_and_tag_vm(qubes, vmname, request):
             },
         }
     )
-    QubeModule(fake_module).run()
     assert vm.features.get("life") is None
     assert vm.features.get("dummy_feature") == "set"
-    assert fake_module.returned_data["diff"]["before"]["features"] == {
+    assert result["diff"]["before"]["features"] == {
         "life": "Going on",
         "dummy_feature": None,
     }
-    assert fake_module.returned_data["diff"]["after"]["features"] == {
+    assert result["diff"]["after"]["features"] == {
         "life": None,
         "dummy_feature": "set",
     }
@@ -338,15 +315,14 @@ def test_properties_and_features_set_and_tag_vm(qubes, vmname, request):
 def test_features_vm(qubes, vmname, request):
     request.node.mark_vm_created(vmname)
     feats = {"life": "Going on", "dummy_feature": None}
-    fake_module = Module(
+    result = run_module(
         {
             "state": "present",
             "name": vmname,
             "features": feats,
         }
     )
-    QubeModule(fake_module).run()
-    feats_values = fake_module.returned_data["diff"]["after"]["features"]
+    feats_values = result["diff"]["after"]["features"]
     assert "life" in feats_values
     assert "dummy_feature" not in feats_values
     for feat, value in feats.items():
@@ -354,65 +330,46 @@ def test_features_vm(qubes, vmname, request):
 
 
 def test_properties_invalid_key(qubes):
-    # Unknown property should fail
-    fake_module = Module(
-        {
-            "state": "present",
-            "name": "dom0",
-            "properties": {"titi": "toto"},
-        }
-    )
-
-    try:
-        QubeModule(fake_module).run()
-    except ModuleExitWithError:
-        assert "Invalid property" in fake_module.returned_data["msg"]
-    else:
-        pytest.fail("Module should have raised an error")
+    with pytest.raises(AnsibleFailJson) as exc:
+        run_module(
+            {
+                "state": "present",
+                "name": "dom0",
+                "properties": {"titi": "toto"},
+            }
+        )
+    assert "Invalid property" in exc.value.args[0]["msg"]
 
 
 def test_properties_invalid_type(qubes, vmname, request):
     request.node.mark_vm_created(vmname)
-    # Wrong type for memory
-    fake_module = Module(
-        {
-            "state": "present",
-            "name": vmname,
-            "properties": {"memory": "toto"},
-        }
-    )
-    try:
-        QubeModule(fake_module).run()
-    except ModuleExitWithError:
-        assert (
-            "Failed to parse property value as int"
-            in fake_module.returned_data["msg"]
+    with pytest.raises(AnsibleFailJson) as exc:
+        run_module(
+            {
+                "state": "present",
+                "name": vmname,
+                "properties": {"memory": "toto"},
+            }
         )
-    else:
-        pytest.fail("Module should have raised an error")
+    assert "Failed to parse property value as int" in exc.value.args[0]["msg"]
 
 
 def test_properties_missing_netvm(qubes, vmname):
     # netvm does not exist
-    fake_module = Module(
-        {
-            "state": "present",
-            "name": vmname,
-            "properties": {"netvm": "toto"},
-        }
-    )
-    try:
-        QubeModule(fake_module).run()
-    except ModuleExitWithError:
-        assert (
-            "Cannot set value 'toto' to property 'netvm': the qube doesn't exist"
-            in fake_module.returned_data["msg"]
+    with pytest.raises(AnsibleFailJson) as exc:
+        run_module(
+            {
+                "state": "present",
+                "name": vmname,
+                "properties": {"netvm": "toto"},
+            }
         )
-
-        # Error should be raised before trying to create the qube
-        assert vmname not in qubes.domains
-    else:
-        pytest.fail("Module should have raised an error")
+    assert (
+        "Cannot set value 'toto' to property 'netvm': the qube doesn't exist"
+        in exc.value.args[0]["msg"]
+    )
+    # Error should be raised before trying to create the qube
+    assert vmname not in qubes.domains
 
 
 def test_properties_reset_to_default_netvm(qubes, vm, netvm):
@@ -422,42 +379,28 @@ def test_properties_reset_to_default_netvm(qubes, vm, netvm):
     default_netvm = vm.netvm
 
     # Change to non-default netvm
-    fake_module = Module(
+    result = run_module(
         {
             "state": "present",
             "name": vm.name,
             "properties": {"netvm": netvm.name},
         }
     )
-    QubeModule(fake_module).run()
 
-    assert (
-        fake_module.returned_data["diff"]["before"]["properties"]["netvm"]
-        == "*default*"
-    )
-    assert (
-        fake_module.returned_data["diff"]["after"]["properties"]["netvm"]
-        == netvm.name
-    )
+    assert result["diff"]["before"]["properties"]["netvm"] == "*default*"
+    assert result["diff"]["after"]["properties"]["netvm"] == netvm.name
 
     # Ability to reset back to default netvm, whichever it is
-    fake_module = Module(
+    result = run_module(
         {
             "state": "present",
             "name": vm.name,
             "properties": {"netvm": "*default*"},
         }
     )
-    QubeModule(fake_module).run()
 
-    assert (
-        fake_module.returned_data["diff"]["before"]["properties"]["netvm"]
-        == netvm.name
-    )
-    assert (
-        fake_module.returned_data["diff"]["after"]["properties"]["netvm"]
-        == "*default*"
-    )
+    assert result["diff"]["before"]["properties"]["netvm"] == netvm.name
+    assert result["diff"]["after"]["properties"]["netvm"] == "*default*"
     assert default_netvm != netvm
 
     qubes.domains.refresh_cache(force=True)
@@ -474,40 +417,28 @@ def test_properties_reset_to_default_mac(qubes, vm, request):
     mac = "11:22:33:44:55:66"
 
     # Change to non-default mac
-    fake_module = Module(
+    result = run_module(
         {
             "state": "present",
             "name": vm.name,
             "properties": {"mac": mac},
         }
     )
-    QubeModule(fake_module).run()
 
-    assert (
-        fake_module.returned_data["diff"]["before"]["properties"]["mac"]
-        == "*default*"
-    )
-    assert (
-        fake_module.returned_data["diff"]["after"]["properties"]["mac"] == mac
-    )
+    assert result["diff"]["before"]["properties"]["mac"] == "*default*"
+    assert result["diff"]["after"]["properties"]["mac"] == mac
 
     # Ability to reset back to default mac, whatever it is
-    fake_module = Module(
+    result = run_module(
         {
             "state": "present",
             "name": vm.name,
             "properties": {"mac": "*default*"},
         }
     )
-    QubeModule(fake_module).run()
 
-    assert (
-        fake_module.returned_data["diff"]["before"]["properties"]["mac"] == mac
-    )
-    assert (
-        fake_module.returned_data["diff"]["after"]["properties"]["mac"]
-        == "*default*"
-    )
+    assert result["diff"]["before"]["properties"]["mac"] == mac
+    assert result["diff"]["after"]["properties"]["mac"] == "*default*"
     assert default_mac != mac
 
     qubes.domains.refresh_cache(force=True)
@@ -516,74 +447,64 @@ def test_properties_reset_to_default_mac(qubes, vm, request):
 
 def test_properties_missing_default_dispvm(qubes):
     # default_dispvm does not exist
-    fake_module = Module(
-        {
-            "state": "present",
-            "name": "dom0",
-            "properties": {"default_dispvm": "toto"},
-        }
-    )
-    try:
-        QubeModule(fake_module).run()
-    except ModuleExitWithError:
-        assert (
-            "Cannot set value 'toto' to property 'default_dispvm': the qube doesn't exist"
-            in fake_module.returned_data["msg"]
+    with pytest.raises(AnsibleFailJson) as exc:
+        run_module(
+            {
+                "state": "present",
+                "name": "dom0",
+                "properties": {"default_dispvm": "toto"},
+            }
         )
-    else:
-        pytest.fail("Module should have raised an error")
+    assert (
+        "Cannot set value 'toto' to property 'default_dispvm': the qube doesn't exist"
+        in exc.value.args[0]["msg"]
+    )
 
 
 def test_properties_invalid_volume_name_for_appvm(qubes, vmname, request):
     # volume name not allowed for AppVM
-    fake_module = Module(
-        {
-            "state": "present",
-            "name": vmname,
-            "volumes": {"root": {"size": 10}},
-        }
-    )
-    try:
-        QubeModule(fake_module).run()
-    except ModuleExitWithError:
-        assert (
-            "Cannot change root volume config for 'AppVM"
-            in fake_module.returned_data["msg"]
+    with pytest.raises(AnsibleFailJson) as exc:
+        run_module(
+            {
+                "state": "present",
+                "name": vmname,
+                "volumes": {"root": {"size": 10}},
+            }
         )
-    else:
-        pytest.fail("Module should have raised an error")
+    assert (
+        "Cannot change root volume config for 'AppVM"
+        in exc.value.args[0]["msg"]
+    )
 
 
 def test_notes(qubes, vmname, request):
-    fake_module = Module(
-        {
-            "state": "present",
-            "name": vmname,
-            "notes": "For your eyes only",
-        }
-    )
-    QubeModule(fake_module).run()
+    params = {
+        "state": "present",
+        "name": vmname,
+        "notes": "For your eyes only",
+    }
+    result = run_module(params)
     assert qubes.domains[vmname].get_notes() == "For your eyes only"
-    assert (
-        fake_module.returned_data["diff"]["after"]["notes"]
-        == "For your eyes only"
-    )
+    assert result["diff"]["after"]["notes"] == "For your eyes only"
 
     # The 2nd call should not change the notes
-    QubeModule(fake_module).run()
-    assert not fake_module.returned_data["changed"]
+    result = run_module(params)
+    assert not result["changed"]
 
 
 def test_services_aliased_to_features_only(qubes, vmname, request):
     request.node.mark_vm_created(vmname)
 
     services = ["clocksync", "minimal-netvm"]
-    fake_module = Module(
-        {"state": "present", "name": vmname, "services": services}
+    result = run_module(
+        {
+            "state": "present",
+            "name": vmname,
+            "services": services,
+        }
     )
-    QubeModule(fake_module).run()
 
-    assert fake_module.returned_data["changed"]
+    assert result["changed"]
 
     # And the VM should now have service.<svc> = 1 for each
     qube = qubes.domains[vmname]
@@ -600,14 +521,13 @@ def test_devices_strict_single_pci_assignment(
     port = latest_net_ports[-1]
 
     # Create VM in strict mode with only one PCI device
-    fake_module = Module(
+    run_module(
         {
             "state": "present",
             "name": vmname,
             "devices": [port],
         }
     )
-    QubeModule(fake_module).run()
 
     qubes.domains.refresh_cache(force=True)
     assigned = qubes.domains[vmname].devices["pci"].get_assigned_devices()
@@ -628,15 +548,13 @@ def test_devices_explicit_strict_assignment(
     request.node.mark_vm_created(vmname)
     port = latest_net_ports[-1]
 
-    # Create VM in strict mode with only one PCI device
-    fake_module = Module(
+    run_module(
         {
             "state": "present",
             "name": vmname,
             "devices": {"strategy": "strict", "items": [port]},
         }
     )
-    QubeModule(fake_module).run()
 
     qubes.domains.refresh_cache(force=True)
     assigned = qubes.domains[vmname].devices["pci"].get_assigned_devices()
@@ -658,14 +576,13 @@ def test_devices_strict_multiple_with_block(
     # Use both PCI net devices plus the block device
     devices = [latest_net_ports[-2], latest_net_ports[-1], block_device]
 
-    fake_module = Module(
+    run_module(
         {
             "state": "present",
             "name": vmname,
             "devices": devices,
         }
     )
-    QubeModule(fake_module).run()
 
     qubes.domains.refresh_cache(force=True)
     pci_assigned = qubes.domains[vmname].devices["pci"].get_assigned_devices()
@@ -695,17 +612,16 @@ def test_devices_append_strategy_adds_without_removal(
     second_port = latest_net_ports[-1]
 
     # Initial create with first PCI port
-    fake_module = Module(
+    run_module(
         {
             "state": "present",
             "name": vmname,
             "devices": [first_port],
         }
     )
-    QubeModule(fake_module).run()
 
     # Re-run with append strategy: add second PCI and block, keep first
-    fake_module = Module(
+    run_module(
         {
             "state": "present",
             "name": vmname,
@@ -715,7 +631,6 @@ def test_devices_append_strategy_adds_without_removal(
             },
         }
     )
-    QubeModule(fake_module).run()
 
     qubes.domains.refresh_cache(force=True)
     pci_ports = [
@@ -749,14 +664,13 @@ def test_devices_per_device_mode_and_options(
         "options": {"no-strict-reset": True},
     }
 
-    fake_module = Module(
+    run_module(
         {
             "state": "present",
             "name": vmname,
             "devices": [entry],
         }
     )
-    QubeModule(fake_module).run()
 
     qubes.domains.refresh_cache(force=True)
     assigned = list(qubes.domains[vmname].devices["pci"].get_assigned_devices())
@@ -775,22 +689,19 @@ def test_devices_strict_idempotent_sync(
     port = latest_net_ports[-1]
 
     # Initial assignment of a single PCI port
-    fake_module = Module(
-        {
-            "state": "present",
-            "name": vmname,
-            "devices": [port],
-        }
-    )
-    QubeModule(fake_module).run()
+    args = {
+        "state": "present",
+        "name": vmname,
+        "devices": [port],
+    }
 
-    assert fake_module.returned_data["changed"]
+    result = run_module(args)
+    assert result["changed"]
 
     # Re-run with the same device list (strict mode) — should be a no-op
-    QubeModule(fake_module).run()
-
+    result = run_module(args)
     # No changes on the second sync
-    assert not fake_module.returned_data["changed"]
+    assert not result["changed"]
 
     # Verify still exactly that one port is assigned
     qubes.domains.refresh_cache(force=True)
@@ -807,16 +718,14 @@ def test_devices_strict_unassign_all(qubes, vmname, request, latest_net_ports):
     ports = latest_net_ports[-2:]
 
     # Assign two PCI ports initially
-    fake_module = Module(
+    result = run_module(
         {
             "state": "present",
             "name": vmname,
             "devices": ports,
         }
     )
-    QubeModule(fake_module).run()
-
-    assert fake_module.returned_data["changed"]
+    assert result["changed"]
 
     qubes.domains.refresh_cache(force=True)
 
@@ -828,21 +737,18 @@ def test_devices_strict_unassign_all(qubes, vmname, request, latest_net_ports):
     assert initial == set(ports)
 
     # Now sync to an empty list (strict default) to remove all devices
-    fake_module = Module(
+    result = run_module(
         {
             "state": "present",
             "name": vmname,
             "devices": [],  # strict empty
         }
     )
-    QubeModule(fake_module).run()
 
     # Should report that it changed by removing devices
-    assert fake_module.returned_data["changed"]
-    assert (
-        len(fake_module.returned_data["diff"]["before"]["devices"]["pci"]) == 2
-    )
-    assert fake_module.returned_data["diff"]["after"]["devices"]["pci"] == {}
+    assert result["changed"]
+    assert len(result["diff"]["before"]["devices"]["pci"]) == 2
+    assert result["diff"]["after"]["devices"]["pci"] == {}
 
     # After removal, no PCI devices should remain assigned
     qubes.domains.refresh_cache(force=True)
@@ -851,17 +757,14 @@ def test_devices_strict_unassign_all(qubes, vmname, request, latest_net_ports):
     )
 
     # And a second empty-sync is a no-op
-    fake_module = Module(
+    result = run_module(
         {
             "state": "present",
             "name": vmname,
             "devices": [],
         }
     )
-
-    QubeModule(fake_module).run()
-
-    assert not fake_module.returned_data["changed"]
+    assert not result["changed"]
 
 
 def test_devices_unchanged(qubes, vmname, request, latest_net_ports):
@@ -869,28 +772,20 @@ def test_devices_unchanged(qubes, vmname, request, latest_net_ports):
     port = latest_net_ports[-1]
 
     # Initial assignment of a single PCI port
-    fake_module = Module(
-        {
-            "state": "present",
-            "name": vmname,
-            "devices": [port],
-        }
-    )
-    QubeModule(fake_module).run()
+    args = {
+        "state": "present",
+        "name": vmname,
+        "devices": [port],
+    }
 
-    assert fake_module.returned_data["changed"]
+    result = run_module(args)
+    assert result["changed"]
 
     # Re-run without devices, should not change anything
-    fake_module = Module(
-        {
-            "state": "present",
-            "name": vmname,
-            "devices": [port],
-        }
-    )
-    QubeModule(fake_module).run()
+    result = run_module(args)
+
     # No changes on the second sync
-    assert not fake_module.returned_data["changed"]
+    assert not result["changed"]
 
     # Verify still exactly that one port is assigned
     qubes.domains.refresh_cache(force=True)
@@ -909,7 +804,7 @@ def test_services_and_explicit_features_combined(qubes, vmname, request):
     features = {"foo": "bar"}
     services = ["audio", "net"]
 
-    fake_module = Module(
+    result = run_module(
         {
             "state": "present",
             "name": vmname,
@@ -917,10 +812,9 @@ def test_services_and_explicit_features_combined(qubes, vmname, request):
             "services": services,
         }
     )
-    QubeModule(fake_module).run()
 
     # The module should report 'features' was updated
-    assert fake_module.returned_data["diff"]["after"]["features"] == {
+    assert result["diff"]["after"]["features"] == {
         "foo": "bar",
         "service.audio": "1",
         "service.net": "1",
@@ -939,17 +833,15 @@ def test_services_and_explicit_features_combined(qubes, vmname, request):
 
 def test_properties_set_kernelopts(qubes, vmname, request):
     request.node.mark_vm_created(vmname)
-    props = {"kernelopts": "swiotlb=4096 foo=bar"}
-    fake_module = Module(
+    result = run_module(
         {
             "state": "present",
             "name": vmname,
-            "properties": props,
+            "properties": {"kernelopts": "swiotlb=4096 foo=bar"},
         }
     )
-    QubeModule(fake_module).run()
     assert (
-        fake_module.returned_data["diff"]["after"]["properties"]["kernelopts"]
+        result["diff"]["after"]["properties"]["kernelopts"]
         == "swiotlb=4096 foo=bar"
     )
     assert qubes.domains[vmname].kernelopts == "swiotlb=4096 foo=bar"
@@ -957,16 +849,14 @@ def test_properties_set_kernelopts(qubes, vmname, request):
 
 def test_properties_set_timeouts(qubes, vmname, request):
     request.node.mark_vm_created(vmname)
-    props = {"qrexec_timeout": 123, "shutdown_timeout": 456}
-    fake_module = Module(
+    result = run_module(
         {
             "state": "present",
             "name": vmname,
-            "properties": props,
+            "properties": {"qrexec_timeout": 123, "shutdown_timeout": 456},
         }
     )
-    QubeModule(fake_module).run()
-    assert fake_module.returned_data["diff"]["after"]["properties"] == {
+    assert result["diff"]["after"]["properties"] == {
         "qrexec_timeout": 123,
         "shutdown_timeout": 456,
     }
@@ -978,21 +868,19 @@ def test_properties_set_timeouts(qubes, vmname, request):
 
 def test_properties_set_ip_ip6_and_mac(qubes, vmname, request):
     request.node.mark_vm_created(vmname)
-    props = {
-        "ip": "10.1.2.3",
-        "ip6": "fe80::1",
-        "mac": "00:11:22:33:44:55",
-    }
-    fake_module = Module(
+    result = run_module(
         {
             "state": "present",
             "name": vmname,
-            "properties": props,
+            "properties": {
+                "ip": "10.1.2.3",
+                "ip6": "fe80::1",
+                "mac": "00:11:22:33:44:55",
+            },
         }
     )
-    QubeModule(fake_module).run()
 
-    assert fake_module.returned_data["diff"]["after"]["properties"] == {
+    assert result["diff"]["after"]["properties"] == {
         "ip": "10.1.2.3",
         "ip6": "fe80::1",
         "mac": "00:11:22:33:44:55",
@@ -1008,17 +896,18 @@ def test_properties_set_management_dispvm_and_audiovm(
     qubes, vmname, managementdvm, audiovm, request
 ):
     request.node.mark_vm_created(vmname)
-    props = {"management_dispvm": managementdvm.name, "audiovm": audiovm.name}
-    fake_module = Module(
+    result = run_module(
         {
             "state": "present",
             "name": vmname,
-            "properties": props,
+            "properties": {
+                "management_dispvm": managementdvm.name,
+                "audiovm": audiovm.name,
+            },
         }
     )
-    QubeModule(fake_module).run()
 
-    assert fake_module.returned_data["diff"]["after"]["properties"] == {
+    assert result["diff"]["after"]["properties"] == {
         "management_dispvm": managementdvm.name,
         "audiovm": audiovm.name,
     }
@@ -1030,17 +919,15 @@ def test_properties_set_management_dispvm_and_audiovm(
 
 def test_properties_set_default_user_and_guivm(qubes, vmname, guivm, request):
     request.node.mark_vm_created(vmname)
-    props = {"default_user": "alice", "guivm": guivm.name}
-    fake_module = Module(
+    result = run_module(
         {
             "state": "present",
             "name": vmname,
-            "properties": props,
+            "properties": {"default_user": "alice", "guivm": guivm.name},
         }
     )
-    QubeModule(fake_module).run()
 
-    assert fake_module.returned_data["diff"]["after"]["properties"] == {
+    assert result["diff"]["after"]["properties"] == {
         "default_user": "alice",
         "guivm": guivm.name,
     }
@@ -1054,35 +941,26 @@ def test_properties_set_default_user_and_guivm(qubes, vmname, guivm, request):
 def test_properties_invalid_type_for_new_properties(qubes, vmname, request):
     request.node.mark_vm_created(vmname)
     # ip must be str, not int
-    fake_module = Module(
-        {
-            "state": "present",
-            "name": vmname,
-            "properties": {"ip": 12345},
-        }
-    )
-
-    try:
-        QubeModule(fake_module).run()
-    except ModuleExitWithError:
-        assert "Invalid property value type" in fake_module.returned_data["msg"]
-    else:
-        pytest.fail("Module should have raised an error")
+    with pytest.raises(AnsibleFailJson) as exc:
+        run_module(
+            {
+                "state": "present",
+                "name": vmname,
+                "properties": {"ip": 12345},
+            }
+        )
+    assert "Invalid property value type" in exc.value.args[0]["msg"]
 
     # qrexec_timeout must be int, not str
-    fake_module = Module(
-        {
-            "state": "present",
-            "name": vmname,
-            "properties": {"qrexec_timeout": "sixty"},
-        }
-    )
-    try:
-        QubeModule(fake_module).run()
-    except ModuleExitWithError:
-        assert "Invalid property value type" in fake_module.returned_data["msg"]
-    else:
-        pytest.fail("Module should have raised an error")
+    with pytest.raises(AnsibleFailJson) as exc:
+        run_module(
+            {
+                "state": "present",
+                "name": vmname,
+                "properties": {"qrexec_timeout": "sixty"},
+            }
+        )
+    assert "Invalid property value type" in exc.value.args[0]["msg"]
 
 
 def test_change_properties_should_occur_only_when_necessary(
@@ -1112,96 +990,95 @@ def test_change_properties_should_occur_only_when_necessary(
         "vcpus": 3,
     }
 
-    fake_module = Module(
+    result = run_module(
         {
             "state": "present",
             "name": vmname,
         }
     )
-    QubeModule(fake_module).run()
-    assert fake_module.returned_data["created"]
+    assert result["created"]
 
-    fake_module = Module(
-        {
-            "state": "present",
-            "name": vmname,
-            "properties": properties,
-        }
-    )
-    QubeModule(fake_module).run()
-
-    assert fake_module.returned_data["changed"]
-    assert fake_module.returned_data["diff"]["before"]["properties"]
-    assert fake_module.returned_data["diff"]["after"]["properties"]
-
-    fake_module = Module(
+    result = run_module(
         {
             "state": "present",
             "name": vmname,
             "properties": properties,
         }
     )
-    QubeModule(fake_module).run()
 
-    assert not fake_module.returned_data["diff"]["before"]
-    assert not fake_module.returned_data["diff"]["after"]
+    assert result["changed"]
+    assert result["diff"]["before"]["properties"]
+    assert result["diff"]["after"]["properties"]
 
-    fake_module = Module(
+    result = run_module(
+        {
+            "state": "present",
+            "name": vmname,
+            "properties": properties,
+        }
+    )
+
+    assert not result["diff"]["before"]
+    assert not result["diff"]["after"]
+
+    run_module(
         {
             "state": "absent",
             "name": vmname,
         }
     )
-    QubeModule(fake_module).run()
 
 
 def test_set_property_to_empty_string(vm, qubes):
-    fake_module = Module(
+    run_module(
         {
             "state": "present",
             "name": vm.name,
             "properties": {"netvm": "sys-net"},
         }
     )
-    QubeModule(fake_module).run()
     assert qubes.domains[vm.name].netvm == "sys-net"
 
-    fake_module = Module(
-        {"state": "present", "name": vm.name, "properties": {"netvm": ""}}
+    run_module(
+        {
+            "state": "present",
+            "name": vm.name,
+            "properties": {"netvm": ""},
+        }
     )
-    QubeModule(fake_module).run()
     assert qubes.domains[vm.name].netvm == None
 
 
 def test_set_property_to_none(vm, qubes):
-    fake_module = Module(
+    run_module(
         {
             "state": "present",
             "name": vm.name,
             "properties": {"netvm": "sys-net"},
         }
     )
-    QubeModule(fake_module).run()
     assert qubes.domains[vm.name].netvm == "sys-net"
 
-    fake_module = Module(
-        {"state": "present", "name": vm.name, "properties": {"netvm": None}}
+    run_module(
+        {
+            "state": "present",
+            "name": vm.name,
+            "properties": {"netvm": None},
+        }
     )
-    QubeModule(fake_module).run()
     assert qubes.domains[vm.name].netvm == None
 
 
 def test_create_vm_which_is_its_self_dispvm(vmname, request, qubes):
     request.node.mark_vm_created(vmname)
 
-    fake_module = Module(
+    run_module(
         {
             "state": "present",
             "name": vmname,
             "properties": {"default_dispvm": vmname},
         }
     )
-    QubeModule(fake_module).run()
     assert qubes.domains[vmname].default_dispvm == vmname
 
 
@@ -1209,46 +1086,62 @@ def test_setting_qube_value_to_the_same_value_than_default(vm):
     assert vm.property_is_default("autostart")
     assert vm.autostart == False
 
-    fake_module = Module(
+    result = run_module(
         {
             "state": "present",
             "name": vm.name,
             "properties": {"autostart": False},
         }
     )
-    QubeModule(fake_module).run()
-    assert fake_module.returned_data["changed"]
-    assert (
-        fake_module.returned_data["diff"]["before"]["properties"]["autostart"]
-        == "*default*"
-    )
-    assert (
-        fake_module.returned_data["diff"]["after"]["properties"]["autostart"]
-        == False
-    )
+    assert result["changed"]
+    assert result["diff"]["before"]["properties"]["autostart"] == "*default*"
+    assert result["diff"]["after"]["properties"]["autostart"] == False
     assert vm.autostart == False
     assert not vm.property_is_default("autostart")
 
     # Idempotence
-    QubeModule(fake_module).run()
-    assert not fake_module.returned_data["changed"]
+    result = run_module(
+        {
+            "state": "present",
+            "name": vm.name,
+            "properties": {"autostart": False},
+        }
+    )
+    assert not result["changed"]
 
-    fake_module = Module(
+    result = run_module(
         {
             "state": "present",
             "name": vm.name,
             "properties": {"autostart": "*default*"},
         }
     )
-    QubeModule(fake_module).run()
-    assert fake_module.returned_data["changed"]
-    assert (
-        fake_module.returned_data["diff"]["before"]["properties"]["autostart"]
-        == False
-    )
-    assert (
-        fake_module.returned_data["diff"]["after"]["properties"]["autostart"]
-        == "*default*"
-    )
+    assert result["changed"]
+    assert result["diff"]["before"]["properties"]["autostart"] == False
+    assert result["diff"]["after"]["properties"]["autostart"] == "*default*"
     assert vm.autostart == False
     assert vm.property_is_default("autostart")
+
+
+def test_no_vm_klass_should_no_try_to_convert_to_appvm(request, vmname, qubes):
+    request.node.mark_vm_created(vmname)
+    run_module(
+        {
+            "state": "present",
+            "name": vmname,
+            "klass": "StandaloneVM",
+            "clone_src": qubes.default_template.name,
+        }
+    )
+    assert qubes.domains[vmname].klass == "StandaloneVM"
+
+    # Start qube without specifying its klass — must NOT try to convert to AppVM
+    run_module(
+        {
+            "state": "running",
+            "name": vmname,
+        }
+    )
+
+    assert qubes.domains[vmname].get_power_state() == "Running"
+    assert qubes.domains[vmname].klass == "StandaloneVM"


### PR DESCRIPTION
This default value was causing side effects. Indeed, when it was not specified in a playbook, the module could attempt to modify the VM class, which resulted in an error.

Example of bugged playbook:

```
- hosts: localhost
  tasks:
    - qubesos.core.qube:
        name: my_qube
        clone_src: fedora-43-xfce
        klass: StandaloneVM
        state: present

    - qubesos.core.qube:
        name: my_qube
        state: running
```

```
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

PLAY [localhost] *********************************************************************************************************************************

TASK [Gathering Facts] ***************************************************************************************************************************
ok: [localhost]

TASK [qubesos.core.qube] *************************************************************************************************************************
changed: [localhost]

TASK [qubesos.core.qube] *************************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Current Qube type is StandaloneVM and cannot be changed to AppVM"}

PLAY RECAP ***************************************************************************************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0 
```