### PR TITLE
Stop playbook execution when a failure occures 

### DIFF
--- a/ansible_collections/qubesos/security/plugins/strategy/qubes_proxy.py
+++ b/ansible_collections/qubesos/security/plugins/strategy/qubes_proxy.py
@@ -637,15 +637,22 @@ class StrategyModule(LinearStrategyModule):
                 stats.increment("ok", host.name)
             else:
                 stats.increment("failures", host.name)
+                # Mark host as failed
+                self._tqm._failed_hosts[host.name] = True
 
         return max(self.qubes_results.values())
 
     def run(self, iterator, play_context):
         play = iterator._play
 
+        # Get previously failed hosts and ignore them.
+        previously_failed = set(iterator.get_failed_hosts().keys())
         target_hosts = self._inventory.get_hosts(play.hosts)
         local_hosts = [
-            host for host in target_hosts if host.name in ["localhost", "dom0"]
+            host
+            for host in target_hosts
+            if host.name in ["localhost", "dom0"]
+            and host.name not in previously_failed
         ]
         retval_local_exec = self._tqm.RUN_OK
 
@@ -653,6 +660,7 @@ class StrategyModule(LinearStrategyModule):
             host
             for host in target_hosts
             if host.name not in ["localhost", "dom0"]
+            and host.name not in previously_failed
         ]
         retval_remote_exec = self._tqm.RUN_OK
 

--- a/ansible_collections/qubesos/security/plugins/strategy/qubes_proxy.py
+++ b/ansible_collections/qubesos/security/plugins/strategy/qubes_proxy.py
@@ -640,7 +640,18 @@ class StrategyModule(LinearStrategyModule):
                 # Mark host as failed
                 self._tqm._failed_hosts[host.name] = True
 
-        return max(self.qubes_results.values())
+
+        # When all hosts failed, we should stop playbook execution
+        if all(rc != 0 for rc in self.qubes_results.values()):
+            return self._tqm.RUN_FAILED_BREAK_PLAY
+
+        # When at least one failure occurred but not for all hosts, mark this
+        # play as failed but continue playbook execution
+        if any(rc != 0 for rc in self.qubes_results.values()):
+            return self._tqm.RUN_FAILED_HOSTS
+
+        # When no error, it's OK!
+        return self._tqm.RUN_OK
 
     def run(self, iterator, play_context):
         play = iterator._play

--- a/ansible_collections/qubesos/security/plugins/strategy/qubes_proxy.py
+++ b/ansible_collections/qubesos/security/plugins/strategy/qubes_proxy.py
@@ -35,6 +35,7 @@ import yaml
 
 from ansible import context
 from ansible.executor.play_iterator import PlayIterator
+from ansible.plugins.strategy import StrategyBase
 from ansible.plugins.strategy.linear import (
     StrategyModule as LinearStrategyModule,
 )
@@ -640,7 +641,6 @@ class StrategyModule(LinearStrategyModule):
                 # Mark host as failed
                 self._tqm._failed_hosts[host.name] = True
 
-
         # When all hosts failed, we should stop playbook execution
         if all(rc != 0 for rc in self.qubes_results.values()):
             return self._tqm.RUN_FAILED_BREAK_PLAY
@@ -692,4 +692,6 @@ class StrategyModule(LinearStrategyModule):
                 play_context,
             )
 
-        return max(retval_local_exec, retval_remote_exec)
+        retval = max(retval_local_exec, retval_remote_exec)
+        # StrategyBase run method will handle cleanup and return correct exit code
+        return StrategyBase.run(self, iterator, play_context, retval)

--- a/tests/qubes/test_cli.py
+++ b/tests/qubes/test_cli.py
@@ -414,3 +414,236 @@ def test_devices_assignment(
         for d in assigned
     ]
     assert ports_assigned == [port]
+
+
+@pytest.mark.parametrize(
+    "ansible_config",
+    ["ansible_proxy_strategy", "ansible_linear_strategy"],
+)
+def test_playbook_execution_stops_for_the_host_only_when_single_host_fails(
+    vmname, run_playbook, request, qubes, ansible_config
+):
+    vm_1 = f"{vmname}_1"
+    vm_2 = f"{vmname}_2"
+
+    request.node.mark_vm_created(vm_1)
+    request.node.mark_vm_created(vm_2)
+
+    playbook = [
+        {
+            "hosts": "localhost",
+            "gather_facts": False,
+            "connection": "ansible.builtin.local",
+            "tasks": [
+                {
+                    "name": f"Create qube {vm_2}",
+                    "qubesos.core.qube": {"name": vm_1, "state": "present"},
+                },
+                {
+                    "name": f"Create qube {vm_2}",
+                    "qubesos.core.qube": {"name": vm_2, "state": "present"},
+                },
+            ],
+        },
+    ]
+
+    playbook_res = run_playbook(playbook)
+    assert playbook_res.returncode == 0, playbook_res.stdout
+    assert vm_1 in qubes.domains
+    assert vm_2 in qubes.domains
+
+    playbook = [
+        # 1st play, adding hosts to appvms group
+        {
+            "hosts": "localhost",
+            "gather_facts": False,
+            "connection": "ansible.builtin.local",
+            "tasks": [
+                {
+                    "ansible.builtin.add_host": {
+                        "name": vm_1,
+                        "groups": "appvms",
+                    },
+                },
+                {
+                    "ansible.builtin.add_host": {
+                        "name": vm_2,
+                        "groups": "appvms",
+                    },
+                },
+            ],
+        },
+        # 2nd play, make vm_2 fail
+        {
+            "hosts": "appvms",
+            "gather_facts": False,
+            "connection": "qubes",
+            "vars": {
+                "cmd": {
+                    f"{vm_1}": "/bin/true",
+                    f"{vm_2}": "/bin/false",
+                }
+            },
+            "tasks": [
+                {
+                    "ansible.builtin.command": "{{ cmd[inventory_hostname] }}",
+                },
+            ],
+        },
+        # 3rd play, only vm_1 should run it
+        {
+            "hosts": "appvms",
+            "gather_facts": False,
+            "connection": "qubes",
+            "tasks": [
+                {
+                    "ansible.builtin.command": "/bin/true",
+                },
+            ],
+        },
+        # 4th play, localhost should run it
+        {
+            "hosts": "localhost",
+            "gather_facts": False,
+            "connection": "ansible.builtin.local",
+            "tasks": [
+                {
+                    "ansible.builtin.command": "/bin/true",
+                },
+            ],
+        },
+    ]
+    playbook_res = run_playbook(playbook)
+    assert playbook_res.returncode == 2, playbook_res.stdout
+
+    lines = playbook_res.stdout.split("\n")
+    json_begin = lines.index("{")
+    results_json = json.loads("\n".join(lines[json_begin:]))
+
+    # 4 plays ran
+    assert len(results_json["plays"]) == 4
+
+    # 1st play: 2x add_host
+    # 4th play: 1x command
+    assert results_json["stats"]["localhost"]["ok"] == 3
+    assert results_json["stats"]["localhost"]["failures"] == 0
+
+    # 2nd play + 3rd play
+    assert results_json["stats"][vm_1]["ok"] == 2
+    assert results_json["stats"][vm_1]["failures"] == 0
+
+    # 2nd play failed, 3rd must not be executed
+    assert results_json["stats"][vm_2]["ok"] == 0
+    assert results_json["stats"][vm_2]["failures"] == 1
+
+
+@pytest.mark.parametrize(
+    "ansible_config",
+    ["ansible_proxy_strategy", "ansible_linear_strategy"],
+)
+def test_playbook_execution_stops_whole_playbook_execution_when_all_hosts_fail(
+    vmname, run_playbook, request, qubes, ansible_config
+):
+    vm_1 = f"{vmname}_1"
+    vm_2 = f"{vmname}_2"
+
+    request.node.mark_vm_created(vm_1)
+    request.node.mark_vm_created(vm_2)
+
+    playbook = [
+        {
+            "hosts": "localhost",
+            "gather_facts": False,
+            "connection": "ansible.builtin.local",
+            "tasks": [
+                {
+                    "name": f"Create qube {vm_2}",
+                    "qubesos.core.qube": {"name": vm_1, "state": "present"},
+                },
+                {
+                    "name": f"Create qube {vm_2}",
+                    "qubesos.core.qube": {"name": vm_2, "state": "present"},
+                },
+            ],
+        },
+    ]
+
+    playbook_res = run_playbook(playbook)
+    assert playbook_res.returncode == 0, playbook_res.stdout
+    assert vm_1 in qubes.domains
+    assert vm_2 in qubes.domains
+
+    playbook = [
+        # 1st play, adding hosts to appvms group
+        {
+            "hosts": "localhost",
+            "gather_facts": False,
+            "connection": "ansible.builtin.local",
+            "tasks": [
+                {
+                    "ansible.builtin.add_host": {
+                        "name": vm_1,
+                        "groups": "appvms",
+                    },
+                },
+                {
+                    "ansible.builtin.add_host": {
+                        "name": vm_2,
+                        "groups": "appvms",
+                    },
+                },
+            ],
+        },
+        # 2nd play, make all vm fail
+        {
+            "hosts": "appvms",
+            "gather_facts": False,
+            "connection": "qubes",
+            "tasks": [
+                {
+                    "ansible.builtin.command": "/bin/false",
+                },
+            ],
+        },
+        # 3rd play - should not be executed
+        {
+            "hosts": "appvms",
+            "gather_facts": False,
+            "connection": "qubes",
+            "tasks": [
+                {
+                    "ansible.builtin.command": "/bin/true",
+                },
+            ],
+        },
+        # 4th play - should not be executed
+        {
+            "hosts": "localhost",
+            "gather_facts": False,
+            "connection": "ansible.builtin.local",
+            "tasks": [
+                {
+                    "ansible.builtin.command": "/bin/true",
+                },
+            ],
+        },
+    ]
+    playbook_res = run_playbook(playbook)
+    assert playbook_res.returncode == 2, playbook_res.stdout
+
+    lines = playbook_res.stdout.split("\n")
+    json_begin = lines.index("{")
+    results_json = json.loads("\n".join(lines[json_begin:]))
+
+    # Only 2 play ran
+    assert len(results_json["plays"]) == 2
+
+    # 1st play: 2x add_host
+    assert results_json["stats"]["localhost"]["ok"] == 2
+    assert results_json["stats"]["localhost"]["failures"] == 0
+
+    # 2nd play only
+    assert results_json["stats"][vm_1]["ok"] == 0
+    assert results_json["stats"][vm_1]["failures"] == 1
+    assert results_json["stats"][vm_2]["ok"] == 0
+    assert results_json["stats"][vm_2]["failures"] == 1


### PR DESCRIPTION
When using the proxy plugin, host failures were not taken into account, so failed hosts continued to execute subsequent plays in the playbook.

When using the linear strategy, behavior is different:
  - when a host fails a task in a play, it is marked as failed and is excluded for the remaining plays
  - when all hosts targeted to a play fail a task, playbook execution is interrupted

Proxy plugin has been fixed and behaves this way too.

This PR also fixes the return code of `ansible-playbook` command. Previously, the last play result was the returned exit code. Now, the module relies on the `StrategyBase` class that checks for previous failed plays to determine the relevant code to return.

Fixes: https://github.com/QubesOS/qubes-issues/issues/10431