### PR TITLE
Fix services fact (would return single char)

### DIFF
--- a/ansible_collections/qubesos/core/plugins/modules/qube_facts.py
+++ b/ansible_collections/qubesos/core/plugins/modules/qube_facts.py
@@ -186,7 +186,7 @@ def core(module):
                 },
                 "notes": qube.get_notes(),
                 "services": {
-                    feat[len("service.")]: bool(qube.features[feat])
+                    feat[len("service.") :]: bool(qube.features[feat])
                     for feat in qube.features
                     if feat.startswith("service.")
                 },


### PR DESCRIPTION
The problem:
```
>>> import qubesadmin
>>> qube = qubesadmin.Qubes().domains['sys-net']
>>> {feat[len("service.")]: bool(qube.features[feat]) for feat in qube.features if feat.startswith("service.")}
{'c': True, 'q': True}
```
As you can see, it only has one char as the key. With the fix:
```
>>> {feat[len("service."):]: bool(qube.features[feat]) for feat in qube.features if feat.startswith("service.")}
{'clocksync': True, 'qubes-updates-proxy': True}
```