### PR TITLE
proxy: allow forwarding vault secrets to the management DispVM

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,47 @@ the symlink before building the archive.
 
 See the [examples](EXAMPLES.md) for sample playbooks and role tasks demonstrating common usage scenarios.
 
+## Vault
+
+Ansible Vault can be used together with the proxy strategy in two different ways.
+
+### 1. Encrypted variables (decrypted in dom0 / ManagementVM)
+
+When you encrypt variables stored in your inventory (`host_vars`, `group_vars`) or in
+vault-encrypted vars files, they are decrypted where Ansible runs (dom0 or the
+ManagementVM). The proxy strategy then treats them like any other host variable: they are
+merged into the single `host_vars/<host>.yaml` file that is copied to the disposable VM.
+
+This means the values travel to the disposable VM **in clear text** inside that concatenated
+YAML file, and the vault password is **never** copied to the disposable VM. Use this when it
+is acceptable for dom0 / the ManagementVM to see the decrypted values, or when you don't want to copy the vault file to the disposable VM.
+
+### 2. Passing vault secrets to the disposable VM
+
+If, instead, you want vault-encrypted content to be decrypted **inside the disposable VM**
+(for example to keep an encrypted file encrypted until it reaches the target), set the
+`qubes_proxy_pass_vault_secret` variable in the play variables to the list of vault ids whose passwords should be
+forwarded to the disposable VM:
+
+```yaml
+- hosts: work
+  connection: qubes
+  strategy: qubes_proxy
+  vars:
+    qubes_proxy_pass_vault_secret:
+      - default
+      - dev
+```
+
+The matching vault passwords are then copied to the disposable VM and passed to
+`ansible-playbook` (as `--vault-password-file` for the `default` id, or `--vault-id
+<id>@<file>` for any other id), so decryption happens on the disposable VM rather than in
+dom0 / the ManagementVM.
+
+The vault passwords must be available to the top-level `ansible-playbook` invocation (e.g.
+via `--vault-id <id>@<source>`), and only the ids listed in `qubes_proxy_pass_vault_secret`
+are forwarded. Requesting an unknown vault id stops execution with an error.
+
 ## Limitations
 
 The proxy plugin may modify the behavior of your playbooks. Please notice the following indications and 

--- a/ansible_collections/qubesos/security/plugins/strategy/qubes_proxy.py
+++ b/ansible_collections/qubesos/security/plugins/strategy/qubes_proxy.py
@@ -17,6 +17,7 @@
 
 import multiprocessing
 import os
+import re
 import shutil
 import subprocess
 import tarfile
@@ -37,6 +38,7 @@ import qubesadmin.exc
 import yaml
 
 from ansible import context
+from ansible.errors import AnsibleError
 from ansible.executor.play_iterator import PlayIterator
 from ansible.plugins.strategy import StrategyBase
 from ansible.plugins.strategy.linear import (
@@ -136,10 +138,15 @@ def filter_control_chars(text: bytes):
     return new_buff
 
 
+class QubesProxyError(AnsibleError):
+    def __init__(self, msg):
+        super().__init__(f"QubesProxy - {msg}")
+
+
 class QubesPlayExecutor:
     """Run plays on a given host through its management disposable VM"""
 
-    def __init__(self, iterator, play_context):
+    def __init__(self, iterator, play_context, vault_secrets):
         self.app = qubesadmin.Qubes()
         self.host = iterator._play.hosts[0]
         self.loader = iterator._variable_manager._loader
@@ -150,6 +157,7 @@ class QubesPlayExecutor:
         self.play = iterator._play
         self.play_context = play_context
         self.variable_manager = iterator._variable_manager
+        self.vault_secrets = vault_secrets
 
         self._dispvm_initially_running = False
 
@@ -166,6 +174,10 @@ class QubesPlayExecutor:
     @property
     def dispvm_mgmt_name(self):
         return f"disp-mgmt-{self.host_name}"[:DISPVM_NAME_MAXLEN]
+
+    @property
+    def tar_file_path(self):
+        return self.temp_dir.parent / f"{self.temp_dir.name}.tar"
 
     def _add_host_vars(self):
         """Build host variables files
@@ -325,6 +337,23 @@ class QubesPlayExecutor:
             seen.add(role_path.name)
             shutil.copytree(role_path, dest_roles_path / role_path.name)
 
+    def _add_vault_secrets(self):
+        """Adds vault secrets files
+
+        These files will be used by ansible-playbook in the DispVM to
+        decrypt the copied vaults
+        """
+        if not self.vault_secrets:
+            return
+
+        vault_secrets_dir = self.temp_dir / "vault_secrets"
+        vault_secrets_dir.mkdir(mode=0o700)
+
+        for vault_id, vault_secret in self.vault_secrets.items():
+            vault_secret_file = vault_secrets_dir / vault_id
+            vault_secret_file.touch(mode=0o600)
+            vault_secret_file.write_bytes(vault_secret)
+
     def _add_rpc_policies(self, dispvm_name):
         self._call_ansible_service_rpc(
             "ansible.CreateManagementPolicies", dispvm_name
@@ -353,8 +382,7 @@ class QubesPlayExecutor:
 
         return subprocess.check_output(command, env=env).decode()
 
-    @staticmethod
-    def _build_ansible_args():
+    def _build_ansible_args(self):
         args = []
         current_args = context.CLIARGS
 
@@ -372,6 +400,13 @@ class QubesPlayExecutor:
             for tag in skip_tags:
                 args += ["--skip-tags", tag]
 
+        for vault_id in self.vault_secrets:
+            vault_path_file = os.path.join("vault_secrets", vault_id)
+            if vault_id == "default":
+                args += ["--vault-password-file", vault_path_file]
+            else:
+                args += ["--vault-id", f"{vault_id}@{vault_path_file}"]
+
         for boolean_arg in ["check", "diff", "force_handlers", "flush_cache"]:
             if current_args.get(boolean_arg):
                 args.append(f"--{boolean_arg.replace('_', '-')}")
@@ -379,7 +414,9 @@ class QubesPlayExecutor:
         return args
 
     def _build_tar(self):
-        tar_file_path = self.temp_dir.parent / f"{self.temp_dir.name}.tar"
+        tar_file_path = self.tar_file_path
+        # the tar may contain vault secrets, keep it private
+        tar_file_path.touch(mode=0o600)
         old_path = os.getcwd()
         os.chdir(self.temp_dir)
         with tarfile.open(tar_file_path, "w") as tar_file:
@@ -432,13 +469,14 @@ class QubesPlayExecutor:
         dispvm = self._start_mgmt_disp_vm()
 
         self._add_rpc_policies(dispvm.name)
-        self.temp_dir.mkdir()
+        self.temp_dir.mkdir(mode=0o700)
 
         try:
             self._add_play(self.play)
             self._add_roles(self.play)
             self._add_host_vars()
             self._add_inventory()
+            self._add_vault_secrets()
             tar_file_path = self._build_tar()
             ansible_args = self._build_ansible_args()
 
@@ -497,6 +535,8 @@ class QubesPlayExecutor:
         finally:
             self._remove_rpc_policies(dispvm.name)
             shutil.rmtree(self.temp_dir)
+            # the tar may contain vault secrets, do not leave it behind
+            self.tar_file_path.unlink(missing_ok=True)
             if not self._dispvm_initially_running:
                 self.vvv(f"Stopping {dispvm.name}")
                 dispvm.kill()
@@ -562,6 +602,47 @@ class StrategyModule(LinearStrategyModule):
 
     def proxy_run(self, iterator, play_context):
         play = iterator._play
+        variable_manager = iterator._variable_manager
+
+        # check if users requested to pass Vault secrets to the DispVM
+        vault_secrets_to_pass = {}
+        qubes_proxy_pass_vault_secret = variable_manager.get_vars(
+            play=play
+        ).get("qubes_proxy_pass_vault_secret")
+        if qubes_proxy_pass_vault_secret:
+            if not isinstance(qubes_proxy_pass_vault_secret, list):
+                raise QubesProxyError(
+                    "Malformed variable 'qubes_proxy_pass_vault_secret': "
+                    f"list expected, got {type(qubes_proxy_pass_vault_secret)}"
+                )
+
+            # vault.secrets => list of [<vault id>, <ansible.parsing.vault.VaultSecret>]
+            vault_secrets = {
+                vault_entry[0]: vault_entry[1].bytes
+                for vault_entry in variable_manager._loader._vault.secrets
+            }
+
+            for vault_id in qubes_proxy_pass_vault_secret:
+                # the vault id is used as a file name in the DispVM and in
+                # the --vault-id <id>@<file> argument
+                if not re.fullmatch(r"[\w.-]+", str(vault_id)):
+                    raise QubesProxyError(
+                        f"Invalid vault id '{vault_id}': only letters, "
+                        "digits, '_', '.' and '-' are allowed"
+                    )
+                try:
+                    vault_secrets_to_pass[vault_id] = vault_secrets[vault_id]
+                except KeyError:
+                    raise QubesProxyError(
+                        "Trying to pass vault secret of an unknown vault: "
+                        f"{vault_id}"
+                    )
+
+            display.vvv(
+                "<QubesOS> Secrets of the following vault(s) will be "
+                f"copied: {', '.join(vault_secrets_to_pass.keys())}"
+            )
+
         display.vvv(
             f"<QubesOS> Running play {play} " f"with {self._tqm._forks} forks"
         )
@@ -580,7 +661,7 @@ class StrategyModule(LinearStrategyModule):
                 iterator, play_context, [host]
             )
             QUBES_PLAY_EXECUTORS[host.name] = QubesPlayExecutor(
-                new_iterator, play_context
+                new_iterator, play_context, vault_secrets_to_pass
             )
 
         # Now that everything is ready, run the executor for each host using multiprocessing

--- a/qubes-rpc/qubes.AnsibleVM
+++ b/qubes-rpc/qubes.AnsibleVM
@@ -10,14 +10,17 @@ for i in $(seq 100); do
   ansible_args+=("$item")
 done
 
-temp_dir="$(mktemp -d)"
-
-# shellcheck disable=SC2064
-trap "rm -rf '$temp_dir'" EXIT
-
 tar_file_path="/home/user/QubesIncoming/${QREXEC_REMOTE_DOMAIN}/${tar_file}"
 [ -f "$tar_file_path" ] || exit 1
 
-tar -C "$temp_dir" -xf "$tar_file_path"
+temp_dir="$(mktemp -d)"
 
-ANSIBLE_FORCE_COLOR=True ansible-playbook -i "${temp_dir}/inventory" "${ansible_args[@]}" "${temp_dir}/playbook.yaml"
+# the tar may contain vault secrets, do not leave it behind
+# shellcheck disable=SC2064
+trap "rm -rf '$temp_dir' '$tar_file_path'" EXIT
+
+tar -C "$temp_dir" -xf "$tar_file_path" || exit 1
+
+cd "$temp_dir" || exit 1
+
+ANSIBLE_FORCE_COLOR=True ansible-playbook -i "inventory" "${ansible_args[@]}" "playbook.yaml"

--- a/tests/qubes/conftest.py
+++ b/tests/qubes/conftest.py
@@ -1,6 +1,8 @@
 import subprocess
+import shutil
 import sys
 import uuid
+import yaml
 
 import pytest
 import qubesadmin
@@ -185,12 +187,16 @@ def run_playbook(tmp_path, ansible_config):
     ansible_config_path = Path(__file__).parent.parent / f"{ansible_config}.cfg"
     assert ansible_config_path.is_file()
 
-    def _run(playbook_content: List[dict], vms: List[str] = []):
+    def _run(
+        playbook_content: List[dict],
+        vms: List[str] = [],
+        extra_args=[],
+        roles_path=None,
+    ):
         # Create playbook file
         pb_file = tmp_path / "playbook.yml"
-        import yaml
-
         pb_file.write_text(yaml.dump(playbook_content))
+
         # Run ansible-playbook
         cmd = [
             "ansible-playbook",
@@ -198,6 +204,7 @@ def run_playbook(tmp_path, ansible_config):
             f"localhost,dom0,{','.join(vms)}",
             "-c",
             "local",
+            *extra_args,
             "-M",
             str(PLUGIN_PATH),
             str(pb_file),

--- a/tests/qubes/test_cli.py
+++ b/tests/qubes/test_cli.py
@@ -2,6 +2,7 @@ import subprocess
 import uuid
 import json
 import pytest
+import yaml
 
 from conftest import PLUGIN_PATH
 
@@ -647,3 +648,129 @@ def test_playbook_execution_stops_whole_playbook_execution_when_all_hosts_fail(
     assert results_json["stats"][vm_1]["failures"] == 1
     assert results_json["stats"][vm_2]["ok"] == 0
     assert results_json["stats"][vm_2]["failures"] == 1
+
+
+def _generate_vault_and_role(tmp_path, vault_id=None):
+    vault_content = {"var_from_role_vault": "my_role_var"}
+    role_content = [
+        {"ansible.builtin.assert": {"that": "var_from_role_vault is defined"}},
+    ]
+    vault_secret = "Secret123!"
+
+    roles_path = tmp_path / "roles"
+    roles_path.mkdir()
+    my_role_path = roles_path / "my_role"
+    my_role_path.mkdir()
+    (my_role_path / "tasks").mkdir()
+    (my_role_path / "vars").mkdir()
+    vault_path = (my_role_path / "vars") / "main.yml"
+    role_main_path = (my_role_path / "tasks") / "main.yml"
+
+    yaml.dump(vault_content, vault_path.open("w"))
+    yaml.dump(role_content, role_main_path.open("w"))
+
+    secret_file = tmp_path / "secret.txt"
+    secret_file.write_text(vault_secret)
+
+    # Create the vault
+    if vault_id:
+        args = [
+            "--vault-id",
+            f"my_role@{secret_file}",
+            vault_path,
+        ]
+    else:
+        args = [
+            "--vault-password-file",
+            secret_file,
+            vault_path,
+        ]
+
+    result = subprocess.run(["ansible-vault", "encrypt", *args])
+
+    assert result.returncode == 0
+    assert "AES" in vault_path.read_text()
+
+
+@pytest.mark.parametrize(
+    "ansible_config",
+    ["ansible_proxy_strategy"],
+)
+def test_playbook_with_vault_in_role_no_password(
+    vm, run_playbook, tmp_path, ansible_config
+):
+    _generate_vault_and_role(tmp_path)
+
+    playbook = [
+        {
+            "hosts": vm.name,
+            "gather_facts": False,
+            "connection": "qubesos.security.qubes_proxy",
+            "roles": ["my_role"],
+        }
+    ]
+
+    result = run_playbook(playbook_content=playbook, vms=[vm.name])
+    assert result.returncode != 0
+    assert (
+        "ERROR! Attempting to decrypt but no vault secrets found"
+        in result.stderr
+    )
+
+
+@pytest.mark.parametrize(
+    "ansible_config",
+    ["ansible_proxy_strategy"],
+)
+def test_playbook_with_vault_with_vault_password_file(
+    vm, run_playbook, tmp_path, ansible_config
+):
+    _generate_vault_and_role(tmp_path)
+
+    playbook = [
+        {
+            "hosts": vm.name,
+            "gather_facts": False,
+            "connection": "qubesos.security.qubes_proxy",
+            "roles": ["my_role"],
+            "vars": {"qubes_proxy_pass_vault_secret": ["default"]},
+        }
+    ]
+
+    result = run_playbook(
+        playbook_content=playbook,
+        vms=[vm.name],
+        extra_args=["--vault-password-file", tmp_path / "secret.txt"],
+    )
+    assert result.returncode == 0
+
+
+@pytest.mark.parametrize(
+    "ansible_config",
+    ["ansible_proxy_strategy"],
+)
+def test_playbook_with_vault_with_vault_id(
+    vm, run_playbook, tmp_path, ansible_config
+):
+    _generate_vault_and_role(tmp_path, "my_role")
+
+    playbook = [
+        {
+            "hosts": vm.name,
+            "gather_facts": False,
+            "connection": "qubesos.security.qubes_proxy",
+            "roles": ["my_role"],
+            "vars": {
+                "qubes_proxy_pass_vault_secret": [
+                    "my_role",
+                ]
+            },
+        }
+    ]
+
+    result = run_playbook(
+        playbook_content=playbook,
+        vms=[vm.name],
+        extra_args=["--vault-id", f"my_role@{tmp_path / 'secret.txt'}"],
+    )
+    assert result.returncode == 0


### PR DESCRIPTION
## Summary

When using vaults in inventory vars, dom0's Ansible decrypts vault content and
values are threated like any other inventory variable: the host's associated values are copied to the disposable VM in clear text inside the merged
`host_vars/<host>.yaml` file. This is fine when using inventory variables and when dom0 may see the decrypted values, but
it does not allow keeping content encrypted until it reaches the target or working with vaults in roles.

This PR adds an opt-in way to forward vault passwords to the management DispVM so
that decryption happens **inside the disposable VM** instead of in dom0 /
ManagementVM.

## What's new

- New play variable **`qubes_proxy_pass_vault_secret`**: a list of vault ids whose
  passwords should be forwarded to the disposable VM. Only the listed ids are sent.

  ```yaml
  - hosts: work
    connection: qubes
    strategy: qubes_proxy
    vars:
      qubes_proxy_pass_vault_secret:
        - default
        - my_role_vault

The matching secrets are written into the archive sent to the DispVM, and the executor adds the corresponding arguments to the in-VM ansible-playbook call: `--vault-password-file` for the default id, `--vault-id <id>@<file>` for any other id.
qubes.AnsibleVM now cds into the extracted directory so vault files are resolved by relative path.



Fixes https://github.com/QubesOS/qubes-issues/issues/10307